### PR TITLE
Refactor: Migrate to esp-hal v1.1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,93 +1,66 @@
 # Cargo configuration for esp-csi-rs
 #
-# This file documents the available Cargo aliases and target-specific settings
-# used when building and flashing ESP targets. It is included in docs.rs so
-# users can quickly see common commands and tooling expectations.
+# Two flavors of every alias:
+#   `cargo esp32`        — run with println logging (default).
+#   `cargo esp32-defmt`  — run with defmt logging (enables the `defmt` feature
+#                           and tells espflash to decode defmt frames).
+# Replace `esp32` with any of: esp32, esp32c3, esp32c5, esp32c6, esp32s3.
+# `-build` variants compile without flashing/running.
+#
+# The `-Tdefmt.x` linker script is added automatically by `build.rs` whenever
+# the `defmt` cargo feature is on — no need to edit this file to switch.
 
 [alias]
-# Convenience aliases for running examples on supported chips.
-# Example: `cargo esp32 --example wifi_station`
+# Run aliases — println (default).
 esp32 = "run --release --features=esp32   --target=xtensa-esp32-none-elf"
 esp32c3 = "run --release --features=esp32c3 --target=riscv32imc-unknown-none-elf"
+esp32c5 = "run --release --features=esp32c5 --target=riscv32imac-unknown-none-elf"
 esp32c6 = "run --release --features=esp32c6 --target=riscv32imac-unknown-none-elf"
-esp32c2 = "run --release --features=esp32c2 --target=riscv32imc-unknown-none-elf"
 esp32s3 = "run --release --features=esp32s3 --target=xtensa-esp32s3-none-elf"
 
-# Convenience aliases for building release binaries without running.
-esp32-build = "build --release --features=esp32   --target=xtensa-esp32-none-elf"
+# Run aliases — defmt. Override the runner via `--config` so espflash decodes defmt frames.
+esp32-defmt   = "run --release --no-default-features --features=esp32,no-std,auto,defmt,statistics     --target=xtensa-esp32-none-elf       --config=target.xtensa-esp32-none-elf.runner=['espflash','flash','--monitor','--log-format','defmt']"
+esp32c3-defmt = "run --release --no-default-features --features=esp32c3,no-std,auto,defmt,statistics   --target=riscv32imc-unknown-none-elf  --config=target.riscv32imc-unknown-none-elf.runner=['espflash','flash','--monitor','--log-format','defmt']"
+esp32c5-defmt = "run --release --no-default-features --features=esp32c5,no-std,auto,defmt,statistics   --target=riscv32imac-unknown-none-elf --config=target.riscv32imac-unknown-none-elf.runner=['espflash','flash','--monitor','--log-format','defmt']"
+esp32c6-defmt = "run --release --no-default-features --features=esp32c6,no-std,auto,defmt,statistics   --target=riscv32imac-unknown-none-elf --config=target.riscv32imac-unknown-none-elf.runner=['espflash','flash','--monitor','--log-format','defmt']"
+esp32s3-defmt = "run --release --no-default-features --features=esp32s3,no-std,auto,defmt,statistics   --target=xtensa-esp32s3-none-elf      --config=target.xtensa-esp32s3-none-elf.runner=['espflash','flash','--monitor','--log-format','defmt']"
+
+# Build-only variants (no flash/monitor).
+esp32-build   = "build --release --features=esp32   --target=xtensa-esp32-none-elf"
 esp32c3-build = "build --release --features=esp32c3 --target=riscv32imc-unknown-none-elf"
+esp32c5-build = "build --release --features=esp32c5 --target=riscv32imac-unknown-none-elf"
 esp32c6-build = "build --release --features=esp32c6 --target=riscv32imac-unknown-none-elf"
-esp32c2-build = "build --release --features=esp32c2 --target=riscv32imc-unknown-none-elf"
 esp32s3-build = "build --release --features=esp32s3 --target=xtensa-esp32s3-none-elf"
 
+esp32-build-defmt   = "build --release --no-default-features --features=esp32,no-std,auto,defmt,statistics   --target=xtensa-esp32-none-elf"
+esp32c3-build-defmt = "build --release --no-default-features --features=esp32c3,no-std,auto,defmt,statistics --target=riscv32imc-unknown-none-elf"
+esp32c5-build-defmt = "build --release --no-default-features --features=esp32c5,no-std,auto,defmt,statistics --target=riscv32imac-unknown-none-elf"
+esp32c6-build-defmt = "build --release --no-default-features --features=esp32c6,no-std,auto,defmt,statistics --target=riscv32imac-unknown-none-elf"
+esp32s3-build-defmt = "build --release --no-default-features --features=esp32s3,no-std,auto,defmt,statistics --target=xtensa-esp32s3-none-elf"
+
 [target.'cfg(target_arch = "riscv32")']
-# Default runner and linker flags for all RISC-V ESP targets.
-# runner = "espflash flash --monitor --log-format defmt"
 runner = "espflash flash --monitor"
 rustflags = [
   "-C",
   "link-arg=-Tlinkall.x",
-  # Uncomment the following two lines if you want to use defmt
-  # "-C",
-  # "link-arg=-Tdefmt.x",
 ]
 
 [target.'cfg(target_arch = "xtensa")']
-# Default runner and linker flags for all Xtensa ESP targets.
-# Uncomment the following line if you want to use defmt
-# runner = "espflash flash --monitor --log-format defmt"
 runner = "espflash flash --monitor"
 rustflags = [
-  # GNU LD
   "-C",
   "link-arg=-Wl,-Tlinkall.x",
   "-C",
   "link-arg=-nostartfiles",
-  # Uncomment the following two lines if you want to use defmt
-  # "-C",
-  # "link-arg=-Tdefmt.x",
-
-  # LLD
-  # "-C", "link-arg=-Tlinkall.x",
-  # "-C", "linker=rust-lld",
 ]
-
-[target.riscv32imc-unknown-none-elf]
-# Per-target overrides for RISC-V IMC devices (e.g., ESP32-C2/C3).
-# Uncomment the following line if you want to use defmt
-# runner = "espflash flash --monitor --log-format defmt"
-# Comment the following line if you want to use defmt
-runner = "espflash flash --monitor"
-
-[target.riscv32imac-unknown-none-elf]
-# Per-target overrides for RISC-V IMAC devices (e.g., ESP32-C6).
-# Uncomment the following line if you want to use defmt
-# runner = "espflash flash --monitor --log-format defmt"
-# Comment the following line if you want to use defmt
-runner = "espflash flash --monitor"
-
-[target.xtensa-esp32s3-none-elf]
-# Per-target overrides for Xtensa ESP32-S3 devices.
-# Uncomment the following line if you want to use defmt
-# runner = "espflash flash --monitor --log-format defmt"
-# Comment the following line if you want to use defmt
-runner = "espflash flash --monitor"
-
-[target.xtensa-esp32-none-elf]
-# Per-target overrides for Xtensa ESP32 devices.
-# Uncomment the following line if you want to use defmt
-# runner = "espflash flash --monitor --log-format defmt"
-# Comment the following line if you want to use defmt
-runner = "espflash flash --monitor"
-
 
 [env]
 # Default log level for ESP-IDF logging output.
 ESP_LOG = "INFO"
 # Match monitor baud with UART logger baud (see src/lib/logging/logging.rs).
 MONITOR_BAUD = "115200"
-# Uncomment the following line if you want to use defmt
-# DEFMT_LOG = "INFO"
+# defmt log filter (only consulted when the `defmt` feature is on).
+DEFMT_LOG = "info"
 
 [unstable]
 # Build core/alloc for no_std targets.

--- a/.github/workflows/cargo-hack.yml
+++ b/.github/workflows/cargo-hack.yml
@@ -82,11 +82,8 @@ jobs:
           done <<< "${chips}"
 
           all_matrix=$(printf '%s\n' "${entries[@]}" | jq -s -c '.')
-          pr_matrix=$(jq -c '[ .[] | select(.chip == "esp32" or .chip == "esp32c3") ]' <<< "${all_matrix}")
-
-          if [[ "${pr_matrix}" == "[]" ]]; then
-            pr_matrix="${all_matrix}"
-          fi
+          # Run every chip on PRs as well as pushes — keeps coverage uniform.
+          pr_matrix="${all_matrix}"
 
           echo "all_matrix=${all_matrix}" >> "$GITHUB_OUTPUT"
           echo "pr_matrix=${pr_matrix}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cargo-hack.yml
+++ b/.github/workflows/cargo-hack.yml
@@ -66,10 +66,10 @@ jobs:
               esp32s3)
                 target="xtensa-esp32s3-none-elf"
                 ;;
-              esp32c6)
+              esp32c5|esp32c6)
                 target="riscv32imac-unknown-none-elf"
                 ;;
-              esp32c2|esp32c3)
+              esp32c3)
                 target="riscv32imc-unknown-none-elf"
                 ;;
               *)
@@ -121,7 +121,7 @@ jobs:
         run: |
           set -euo pipefail
           cargo +stable install espup --locked
-          espup install --targets esp32,esp32c2,esp32c3,esp32c6,esp32s3
+          espup install --targets esp32,esp32c3,esp32c5,esp32c6,esp32s3
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
@@ -167,3 +167,48 @@ jobs:
               --depth 2 \
               --no-dev-deps
           fi
+
+  cargo-build-defmt:
+    name: build (defmt, ${{ matrix.chip }})
+    runs-on: ubuntu-latest
+    needs: discover-chip-features
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        include: ${{ fromJSON(github.event_name == 'pull_request' && needs.discover-chip-features.outputs.pr_matrix || needs.discover-chip-features.outputs.all_matrix) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: cargo-build-defmt-${{ matrix.chip }}
+
+      - name: Install ESP Rust toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo +stable install espup --locked
+          espup install --targets esp32,esp32c3,esp32c5,esp32c6,esp32s3
+
+      - name: Build with defmt feature stack
+        shell: bash
+        run: |
+          set -euo pipefail
+          source "$HOME/export-esp.sh"
+
+          chip="${{ matrix.chip }}"
+          target="${{ matrix.target }}"
+
+          # Mirror the `cargo <chip>-build-defmt` alias from .cargo/config.toml.
+          cargo build \
+            --release \
+            --no-default-features \
+            --features "${chip},no-std,auto,defmt,statistics" \
+            --target "${target}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "esp-csi-rs"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "defmt 1.0.1",
  "document-features",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,28 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c583acf993cf4245c4acb0a2cc2ab1f9cc097de73411bb6d3647ff6af2b1013d"
-
-[[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "atomic-polyfill"
@@ -78,15 +90,15 @@ dependencies = [
 
 [[package]]
 name = "bt-hci"
-version = "0.6.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb938a3b4c5cc6c2409275bad789c0346a0495fa071a0acc5d72b9bd3175a2f7"
+checksum = "211713d2e9fb4793ce4360a712c0764264aff6be48932ccf02ca2a331c0436a9"
 dependencies = [
  "btuuid",
  "defmt 1.0.1",
  "embassy-sync 0.7.2",
- "embedded-io 0.6.1",
- "embedded-io-async 0.6.1",
+ "embedded-io 0.7.1",
+ "embedded-io-async 0.7.0",
  "futures-intrusive",
  "heapless 0.9.2",
 ]
@@ -101,6 +113,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byte"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21c7ab3e4ae80853c7f8dcdcd904dfa25c02cc373534b8d165194325a088a7cc"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,10 +131,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cc"
+version = "1.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "ccm"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9cf981c7e62b6fb02225592ee7ebf221e0b0b5317984a57a1e9d21af20e317"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "cobs"
@@ -132,6 +181,16 @@ name = "const-default"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
+
+[[package]]
+name = "cordyceps"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a"
+dependencies = [
+ "loom",
+ "tracing",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -156,6 +215,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -303,16 +371,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "defmt-rtt"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d5a25c99d89c40f5676bec8cefe0614f17f0f40e916f98e345dae941807f9e"
-dependencies = [
- "critical-section",
- "defmt 1.0.1",
-]
-
-[[package]]
 name = "delegate"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +392,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "docsplay"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8547ea80db62c5bb9d7796fcce5e6e07d1136bdc1a02269095061e806758fab4"
+dependencies = [
+ "docsplay-macros",
+]
+
+[[package]]
+name = "docsplay-macros"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11772ed3eb3db124d826f3abeadf5a791a557f62c19b123e3f07288158a71fdd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,13 +422,13 @@ dependencies = [
 
 [[package]]
 name = "embassy-embedded-hal"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "554e3e840696f54b4c9afcf28a0f24da431c927f4151040020416e7393d6d0d8"
+checksum = "b0641612053b2f34fc250bb63f6630ae75de46e02ade7f457268447081d709ce"
 dependencies = [
  "embassy-futures",
  "embassy-hal-internal",
- "embassy-sync 0.7.2",
+ "embassy-sync 0.8.0",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
@@ -361,10 +439,11 @@ dependencies = [
 
 [[package]]
 name = "embassy-executor"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06070468370195e0e86f241c8e5004356d696590a678d47d6676795b2e439c6b"
+checksum = "5d0d3b15c9d7dc4fec1d8cb77112472fb008b3b28c51ad23838d83587a6d2f1e"
 dependencies = [
+ "cordyceps",
  "critical-section",
  "defmt 1.0.1",
  "document-features",
@@ -374,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-executor-macros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdddc3a04226828316bf31393b6903ee162238576b1584ee2669af215d55472"
+checksum = "d11a246f53de5f97a387f40ac24726817cd0b6f833e7603baac784f29d6ff276"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -401,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "embassy-hal-internal"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95285007a91b619dc9f26ea8f55452aa6c60f7115a4edc05085cd2bd3127cd7a"
+checksum = "7f10ce10a4dfdf6402d8e9bd63128986b96a736b1a0a6680547ed2ac55d55dba"
 dependencies = [
  "num-traits",
 ]
@@ -453,11 +532,25 @@ checksum = "73974a3edbd0bd286759b3d483540f0ebef705919a5f56f4fc7709066f71689b"
 dependencies = [
  "cfg-if",
  "critical-section",
- "defmt 1.0.1",
  "embedded-io-async 0.6.1",
  "futures-core",
  "futures-sink",
  "heapless 0.8.0",
+]
+
+[[package]]
+name = "embassy-sync"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bbd85cf5a5ae56bdf26f618364af642d1d0a4e245cdd75cd9aabda382f65a81"
+dependencies = [
+ "cfg-if",
+ "critical-section",
+ "defmt 1.0.1",
+ "embedded-io-async 0.7.0",
+ "futures-core",
+ "futures-sink",
+ "heapless 0.9.2",
 ]
 
 [[package]]
@@ -651,9 +744,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "esp-alloc"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641e43d6a60244429117ef2fa7a47182120c7561336ea01f6fb08d634f46bae1"
+checksum = "46ced060d4085858283df950b80a4da2348e1707d7d07b1e966308582dae79f5"
 dependencies = [
  "allocator-api2",
  "cfg-if",
@@ -667,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "esp-backtrace"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3318413fb566c7227387f67736cf70cd74d80a11f2bb31c7b95a9eb48d079669"
+checksum = "37950e24b2dfd98f1581102d1798281d4d9547af881e6bffc2c2b534c026ec8f"
 dependencies = [
  "cfg-if",
  "defmt 1.0.1",
@@ -685,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "esp-bootloader-esp-idf"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a56964ab5479ac20c9cf76fa3b0d3f2233b20b5d8554e81ef5d65f63c20567"
+checksum = "35ffc117c3a9859835d89d0e90f5ee9886ce2264a71a849a7a22ab5308f6653c"
 dependencies = [
  "cfg-if",
  "document-features",
@@ -702,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "esp-config"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102871054f8dd98202177b9890cb4b71d0c6fe1f1413b7a379a8e0841fc2473c"
+checksum = "4d9b92fd9cfb0b4f8f1b6219b9763269a335571e307b014903b8201619374b80"
 dependencies = [
  "document-features",
  "esp-metadata-generated",
@@ -715,15 +808,14 @@ dependencies = [
 
 [[package]]
 name = "esp-csi-rs"
-version = "0.5.12"
+version = "0.5.2"
 dependencies = [
  "defmt 1.0.1",
- "defmt-rtt",
  "document-features",
  "embassy-executor",
  "embassy-futures",
  "embassy-net",
- "embassy-sync 0.7.2",
+ "embassy-sync 0.8.0",
  "embassy-time",
  "embedded-io-async 0.7.0",
  "enumset",
@@ -746,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "esp-hal"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54786287c0a61ca0f78cb0c338a39427551d1be229103b4444591796c579e093"
+checksum = "2bfcf2a0842903717f4663f6a08512c32b0f6b2d7fb7db3c8a6895d2e6d49f72"
 dependencies = [
  "bitfield",
  "bitflags 2.11.0",
@@ -761,7 +853,7 @@ dependencies = [
  "document-features",
  "embassy-embedded-hal",
  "embassy-futures",
- "embassy-sync 0.7.2",
+ "embassy-sync 0.8.0",
  "embassy-usb-driver",
  "embassy-usb-synopsys-otg",
  "embedded-can",
@@ -782,7 +874,9 @@ dependencies = [
  "esp32",
  "esp32c2",
  "esp32c3",
+ "esp32c5",
  "esp32c6",
+ "esp32c61",
  "esp32h2",
  "esp32s2",
  "esp32s3",
@@ -791,6 +885,7 @@ dependencies = [
  "nb 1.1.0",
  "paste",
  "portable-atomic",
+ "rand_core 0.10.1",
  "rand_core 0.6.4",
  "rand_core 0.9.5",
  "riscv",
@@ -804,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "esp-hal-procmacros"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e025a7a7a0affdb4ff913b5c4494aef96ee03d085bf83c27453ae3a71d50da6"
+checksum = "6aebfabb2c21bec45e575e4f6cb6bb7aa8e1b33e7ac45b5dffa0f9d33ff59105"
 dependencies = [
  "document-features",
  "object",
@@ -819,32 +914,43 @@ dependencies = [
 
 [[package]]
 name = "esp-metadata-generated"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a93e39c8ad8d390d248dc7b9f4b59a873f313bf535218b8e2351356972399e3"
+checksum = "42c2ee95b945a4780796e4359e72c033aed3b45073880e8029458f538532db8a"
 
 [[package]]
 name = "esp-phy"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1facf348e1e251517278fc0f5dc134e95e518251f5796cfbb532ca226a29bf"
+checksum = "e7c0a29815cd105ae1a02f3d0c6e7aafda9504a41effae17fac4c3f827719228"
 dependencies = [
  "cfg-if",
  "defmt 1.0.1",
  "document-features",
+ "embassy-sync 0.8.0",
  "esp-config",
  "esp-hal",
  "esp-metadata-generated",
  "esp-sync",
- "esp-wifi-sys",
+ "esp-wifi-sys-esp32",
+ "esp-wifi-sys-esp32c3",
+ "esp-wifi-sys-esp32c5",
+ "esp-wifi-sys-esp32c6",
+ "esp-wifi-sys-esp32s3",
+ "esp32",
+ "esp32c3",
+ "esp32c5",
+ "esp32c6",
+ "esp32s3",
 ]
 
 [[package]]
 name = "esp-println"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a30e6c9fbcc01c348d46706fef8131c7775ab84c254a3cd65d0cd3f6414d592"
+checksum = "42dee1e9ac7c3539bf6464db1707b0edd7557168f98278cf3c84fe70e63c6ce6"
 dependencies = [
+ "defmt 1.0.1",
  "document-features",
  "esp-metadata-generated",
  "esp-sync",
@@ -854,16 +960,18 @@ dependencies = [
 
 [[package]]
 name = "esp-radio"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684c4de2f8907b73c9b891fbda65286a86d34fced4b856f36a7896c211f2f265"
+checksum = "23fbff98b06a96b6ce3791ecec5c668524052a068e23aacd23afe17ddba844ce"
 dependencies = [
  "allocator-api2",
  "bt-hci",
  "cfg-if",
  "defmt 1.0.1",
+ "docsplay",
  "document-features",
  "embassy-net-driver",
+ "embassy-sync 0.8.0",
  "embedded-io 0.6.1",
  "embedded-io 0.7.1",
  "embedded-io-async 0.6.1",
@@ -877,28 +985,45 @@ dependencies = [
  "esp-phy",
  "esp-radio-rtos-driver",
  "esp-sync",
- "esp-wifi-sys",
+ "esp-wifi-sys-esp32",
+ "esp-wifi-sys-esp32c2",
+ "esp-wifi-sys-esp32c3",
+ "esp-wifi-sys-esp32c5",
+ "esp-wifi-sys-esp32c6",
+ "esp-wifi-sys-esp32h2",
+ "esp-wifi-sys-esp32s2",
+ "esp-wifi-sys-esp32s3",
+ "esp32",
+ "esp32c3",
+ "esp32c5",
+ "esp32c6",
+ "esp32s3",
  "heapless 0.9.2",
+ "ieee802154",
  "instability",
  "num-derive",
  "num-traits",
  "portable-atomic",
  "portable_atomic_enum",
- "smoltcp",
  "xtensa-lx-rt",
 ]
 
 [[package]]
 name = "esp-radio-rtos-driver"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "543bc31d1851afd062357e7810c1a9633f282fd3993583499a841ab497cbca6c"
+checksum = "0bd75cd9073a90ffaa53db0bf17df7dc14164f2407a6ff36c725d2d1f78ff494"
+dependencies = [
+ "cfg-if",
+ "esp-sync",
+ "portable-atomic",
+]
 
 [[package]]
 name = "esp-riscv-rt"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502744a5b1e7268d27fd2a4e56ad45efe42ead517d6c517a6961540de949b0ee"
+checksum = "66a814ae91452de56a5e74f69aebfee40579511756837d3774a56fd24cf0ab79"
 dependencies = [
  "defmt 1.0.1",
  "document-features",
@@ -908,26 +1033,31 @@ dependencies = [
 
 [[package]]
 name = "esp-rom-sys"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd66cccc6dd2d13e9f33668a57717ab14a6d217180ec112e6be533de93e7ecbf"
+checksum = "eae852ccb08971155023d1371c96d5490cbc26860f06aee2d629ef73f1a890c3"
 dependencies = [
  "cfg-if",
  "document-features",
  "esp-metadata-generated",
+ "esp32",
+ "esp32c3",
+ "esp32c5",
+ "esp32c6",
+ "esp32s3",
 ]
 
 [[package]]
 name = "esp-rtos"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ec711c8d06e79c67b75d01595539e86b0aac209643af98ca87a12250428b3"
+checksum = "551f90766e1527edaa0c91e8d559e9e2a60397b545e93357ac61fb31845e5712"
 dependencies = [
  "allocator-api2",
  "cfg-if",
  "document-features",
  "embassy-executor",
- "embassy-sync 0.7.2",
+ "embassy-sync 0.8.0",
  "embassy-time-driver",
  "embassy-time-queue-utils",
  "esp-alloc",
@@ -936,21 +1066,25 @@ dependencies = [
  "esp-hal-procmacros",
  "esp-metadata-generated",
  "esp-radio-rtos-driver",
+ "esp-rom-sys",
  "esp-sync",
  "portable-atomic",
+ "riscv",
+ "xtensa-lx",
 ]
 
 [[package]]
 name = "esp-sync"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d44974639b4e88914f83fe60d2832c00276657d7d857628fdfc966cc7302e8a8"
+checksum = "b4736bfbbb9e3f6353344e14fc61b6d18d3b877c3286914cf8c0a037be0ed224"
 dependencies = [
  "cfg-if",
  "defmt 1.0.1",
  "document-features",
  "embassy-sync 0.6.2",
  "embassy-sync 0.7.2",
+ "embassy-sync 0.8.0",
  "esp-metadata-generated",
  "riscv",
  "xtensa-lx",
@@ -970,91 +1104,169 @@ dependencies = [
 ]
 
 [[package]]
-name = "esp-wifi-sys"
-version = "0.8.1"
+name = "esp-wifi-sys-esp32"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b6544f6f0cb86169d1f93ba2101a8d50358a040c5043676ed86b793e09b12c"
+checksum = "2556f38f5292d9735d4e156e276815fc001c9a0a2be0544a575c5fb867129d24"
 dependencies = [
- "anyhow",
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32c2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4b3eb3435dae84de611d4384639e61eed862818223e93fa70c525cb6a70127f"
+dependencies = [
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32c3"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b290846b53db9a3965866964260220b67f2c41cc2dbc0b377e7136239fe168a7"
+dependencies = [
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32c5"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "039337bdc50a40335ed01598e83053164426fed82817492719513d922dcc3592"
+
+[[package]]
+name = "esp-wifi-sys-esp32c6"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57649401fc2f906a16e2268de88693724a125adcd0eba89b594a157affcee2d5"
+dependencies = [
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32h2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf1be2e311f4b4e75b5507c6b007ffc3fcb8c6cb57f83cc6a9569ecdcf58484"
+dependencies = [
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32s2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a9a7f1bc51e7026c3012cda4f11d8799e5e0c0bb3be85797462219def6c26e"
+dependencies = [
+ "defmt 1.0.1",
+]
+
+[[package]]
+name = "esp-wifi-sys-esp32s3"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8321f44b57d8112cbd8607cc83b85783b9195289acb45532728e3e229e7786"
+dependencies = [
  "defmt 1.0.1",
 ]
 
 [[package]]
 name = "esp32"
-version = "0.39.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b76170a463d18f888a1ad258031901036fd827a9ef126733053ba5f8739fb0c8"
+checksum = "5726e07689249d1a2cb7c492077bc424837fb68a64f7eb5d46569325352e9428"
 dependencies = [
- "critical-section",
  "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32c2"
-version = "0.28.0"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62cf8932966b8d445b6f1832977b468178f0a84effb2e9fda89f60c24d45aa3"
+checksum = "5ef0b623533bbaa37e348c18b6b41cfd5b47c3cb64a4b9e44f0295941d62aa2e"
 dependencies = [
- "critical-section",
  "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32c3"
-version = "0.31.0"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356af3771d0d6536c735bf71136594f4d1cbb506abf6e0c51a6639e9bf4e7988"
+checksum = "21e89ed62cf6c043a6d29c520b02a13b359ec8a75d67b65d4330ed717d15fe97"
 dependencies = [
- "critical-section",
+ "defmt 1.0.1",
+ "vcell",
+]
+
+[[package]]
+name = "esp32c5"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6f8ba56195df10224263c60ceb93b4578450019ee838b7338039a281117cb02"
+dependencies = [
  "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32c6"
-version = "0.22.0"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5e511df672d79cd63365c92045135e01ba952b6bddd25b660baff5e1110f6b"
+checksum = "c58f34ff2633968c12125efc7f4f8f101078d5d34c7cb60eab82268db20986f9"
 dependencies = [
- "critical-section",
+ "defmt 1.0.1",
+ "vcell",
+]
+
+[[package]]
+name = "esp32c61"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a926616351b1edfdb50b7ea6451a8dff0c7515c6ceb687063af7d32b117ec0d"
+dependencies = [
  "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32h2"
-version = "0.18.0"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed4a50bbd1380931e095e0973b9b12f782a9c481f2edf1f7c42e7eb4ff736d6d"
+checksum = "c5bab026020ed4606ce113b6fde598dbc48f7eefcc46e9469ece77cc2b1aa4be"
 dependencies = [
- "critical-section",
  "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32s2"
-version = "0.30.0"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98574d4c577fbe888fe3e6df7fc80d25a05624d9998f7d7de1500ae21fcca78f"
+checksum = "d0ad6f21cdf6ec7b06b7f7e0fbe51f0d975fd6a5fa67c3f8a5a910d3981af531"
 dependencies = [
- "critical-section",
  "defmt 1.0.1",
  "vcell",
 ]
 
 [[package]]
 name = "esp32s3"
-version = "0.34.0"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1810d8ee4845ef87542af981e38eb80ab531d0ef1061e1486014ab7af74c337a"
+checksum = "8b4b8c4e4d9f187553ecdb7173edec7b2deb2beea106eedefecdb1654b8ee25a"
 dependencies = [
- "critical-section",
  "defmt 1.0.1",
  "vcell",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -1118,6 +1330,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,6 +1373,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59d2aba832b60be25c1b169146b27c64115470981b128ed84c8db18c1b03c6ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,7 +1409,6 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "defmt 0.3.100",
  "hash32 0.3.1",
  "stable_deref_trait",
 ]
@@ -1200,6 +1437,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "ieee802154"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb6de62f20180795db19ae2ab338852a66f8576581554fa8a730e437b450a5"
+dependencies = [
+ "byte",
+ "ccm",
+ "cipher",
+ "defmt 0.3.100",
+ "hash32 0.2.1",
+ "hash32-derive",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,9 +1471,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling 0.23.0",
  "indoc",
@@ -1262,6 +1513,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,10 +1552,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "managed"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -1320,6 +1599,15 @@ name = "nb"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "num-derive"
@@ -1349,6 +1637,12 @@ checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "paste"
@@ -1489,6 +1783,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "riscv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,6 +1900,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1666,6 +1989,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "smoltcp"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,7 +2018,6 @@ dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "cfg-if",
- "defmt 0.3.100",
  "heapless 0.8.0",
  "managed",
 ]
@@ -1746,6 +2089,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "svgbobdoc"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,6 +2159,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,6 +2195,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1880,6 +2299,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1913,6 +2338,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1941,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "xtensa-lx-rt"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8709f037fb123fe7ff146d2bce86f9dc0dfc53045c016bfd9d703317b6502845"
+checksum = "409a9b4629d429e995cde4dfbd9fe562ccae66f7624514e200733fc5d0ea8905"
 dependencies = [
  "defmt 1.0.1",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "esp-csi-rs"
-version = "0.5.12"
-edition = "2021"
+version = "0.5.2"
+edition = "2024"
 authors = ["Omar Hiari", "Ammar Saleh", "Abdullah Alawad", "Maryam Odat"]
 description = "ESP CSI Driver for Rust"
 keywords = ["embedded", "esp32", "wifi", "csi"]
@@ -28,7 +28,7 @@ auto = ["esp-println/auto"]
 ## Enable logging via defmt.
 defmt = [
     "dep:defmt",
-    "dep:defmt-rtt",
+    "esp-println/defmt-espflash",
     "esp-hal/defmt",
     "esp-radio/defmt",
     "esp-backtrace/defmt",
@@ -57,21 +57,6 @@ esp32 = [
     "esp-radio/csi",
     "esp-radio/sniffer",
     "esp-rtos/esp32",
-]
-
-## Support for the ESP32-C2
-esp32c2 = [
-    "esp-backtrace/esp32c2",
-    "esp-bootloader-esp-idf/esp32c2",
-    "esp-backtrace/println",
-    "esp-hal/esp32c2",
-    "esp-hal/rt",
-    "esp-println/esp32c2",
-    "esp-println/critical-section",
-    "esp-radio/esp32c2",
-    "esp-radio/csi",
-    "esp-radio/sniffer",
-    "esp-rtos/esp32c2",
 ]
 
 ## Support for the ESP32-C3
@@ -115,19 +100,32 @@ esp32s3 = [
     "esp-rtos/esp32s3",
 ]
 
+esp32c5 = [
+    "esp-hal/esp32c5",
+    "esp-hal/rt",
+    "esp-backtrace/esp32c5",
+    "esp-radio/esp32c5",
+    "esp-bootloader-esp-idf/esp32c5",
+    "esp-radio/csi",
+    "esp-radio/sniffer",
+    "esp-println/esp32c5",
+    "esp-println/critical-section",
+    "esp-rtos/esp32c5",
+]
+
 
 [dependencies]
 # Core dependencies required for ESP HAL/RTOS, radio, and networking.
 # Core dependencies
-esp-hal = { version = "~1.0", default-features = false, optional = false, features = [
+esp-hal = { version = "~1.1", default-features = false, optional = false, features = [
     "unstable",
 ] }
-esp-rtos = { version = "0.2.0", optional = false, features = [
+esp-rtos = { version = "0.3.0", optional = false, features = [
     "embassy",
     "esp-alloc",
     "esp-radio",
 ] }
-esp-bootloader-esp-idf = { version = "0.4.0", optional = false, features = [] }
+esp-bootloader-esp-idf = { version = "0.5.0", optional = false, features = [] }
 embassy-net = { version = "0.7.1", features = [
     "dhcpv4",
     "medium-ethernet",
@@ -136,22 +134,20 @@ embassy-net = { version = "0.7.1", features = [
     "raw",
 ] }
 embedded-io-async = { version = "0.7.0", optional = false }
-esp-alloc = { version = "0.9.0", optional = false }
-esp-backtrace = { version = "0.18.1", optional = false, features = [
+esp-alloc = { version = "0.10.0", optional = false }
+esp-backtrace = { version = "0.19.0", optional = false, features = [
     "panic-handler",
 ] }
-esp-println = { version = "0.16.1", optional = false, default-features = false, features = [
+esp-println = { version = "0.17.0", optional = false, default-features = false, features = [
 ] }
-embassy-executor = { version = "0.9.1", optional = false }
+embassy-executor = { version = "0.10.0", optional = false }
 embassy-time = { version = "0.5.0", optional = false }
-esp-radio = { version = "0.17.0", default-features = false, optional = false, features = [
+esp-radio = { version = "0.18.0", default-features = false, optional = false, features = [
     "wifi",
     "sniffer",
     "esp-alloc",
-    "smoltcp",
     "unstable",
     "esp-now",
-    "csi",
 ] }
 smoltcp = { version = "0.12.0", default-features = false, features = [
     "medium-ethernet",
@@ -168,7 +164,7 @@ smoltcp = { version = "0.12.0", default-features = false, features = [
 heapless = { version = "0.7", default-features = false, optional = false, features = [
     "serde",
 ] }
-embassy-sync = { version = "0.7.0", optional = false }
+embassy-sync = { version = "0.8.0", optional = false }
 enumset = { version = "1.1.5", optional = false }
 embassy-futures = "0.1.2"
 static_cell = "2.1.1"
@@ -176,7 +172,6 @@ static_cell = "2.1.1"
 document-features = "0.2.11"
 
 defmt = { version = "1.0.1", optional = true }
-defmt-rtt = { version = "1.1.0", optional = true }
 
 log = { version = "0.4.29", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp-csi-rs"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2024"
 authors = ["Omar Hiari", "Ammar Saleh", "Abdullah Alawad", "Maryam Odat"]
 description = "ESP CSI Driver for Rust"

--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ A Rust crate for collecting **Channel State Information (CSI)** on **ESP32** ser
 
 ## Features
 ### ✅ Device Support
-`esp-csi-rs` supports several ESP devices including the ESP32-C6 which supports WiFi 6. The current list of supported devices are:
+`esp-csi-rs` supports both 2.4 GHz and dual-band ESP devices, including ESP32-C6 (WiFi 6) and ESP32-C5 (WiFi 6 dual-band 2.4/5 GHz). The current list of supported devices is:
 - ESP32
-- ESP32-C2
 - ESP32-C3
-- ESP32-C6
+- ESP32-C5 (2.4/5 GHz)
+- ESP32-C6 (WiFi 6)
 - ESP32-S3
 
 ### ✅ Host Interface
-With exception to the ESP32 and the ESP32-C2, `esp-csi-rs` leverages the `USB-JTAG-SERIAL` peripheral available on many recent ESP development boards. This allows for higher baud rates compared to using the UART interface.
+With exception to the ESP32, `esp-csi-rs` leverages the `USB-JTAG-SERIAL` peripheral available on most recent ESP development boards. This allows for higher baud rates compared to using the UART interface.
 
 ### ✅ `defmt` & Serialized Output
-`esp-csi-rs` reduces device to host transfer overhead further by supporting both serialized output and `defmt`. This allows for better CSI throughput when communicating the output to a host device. `defmt` is a highly efficient logging framework introduced by Ferrous Systems that targets resource-constrained devices. More detail about `defmt` can be found [here](https://defmt.ferrous-systems.com/).
+`esp-csi-rs` reduces device-to-host transfer overhead by supporting both serialized output and `defmt`. The defmt frames are emitted directly over USB-Serial-JTAG via `esp-println`'s `defmt-espflash` backend — `espflash --monitor --log-format defmt` decodes them inline. `defmt` is a highly efficient logging framework introduced by Ferrous Systems that targets resource-constrained devices. More detail about `defmt` can be found [here](https://defmt.ferrous-systems.com/).
 
 ### ✅ Async Logging
 By enabling the optional async-print feature, the crate delegates packet serialization and output to an asynchronous driver. This ensures that heavy I/O operations won't block the async executor. Keeping logging non-blocking is critical for maintaining higher throughput and preventing dropped CSI packets.
@@ -87,17 +87,25 @@ esp-generate --chip=esp32c3 your-project
 Add the crate to your `Cargo.toml`. At a minimum, you would need to specify the device and the desired logging framework (`println` or `defmt`):
 
 ```toml
-esp-csi-rs = { version = "0.3.0", features = ["esp32c3", "println"] }
+esp-csi-rs = { version = "0.5.2", features = ["esp32c3", "println"] }
 ```
 
-> ‼️ The selected logging framework needs to align with the selected framework for the `esp-backtrace` dependency
+The crate uses Rust **edition 2024** and tracks the latest Espressif Rust ecosystem (`esp-hal` 1.1, `esp-radio` 0.18, `esp-rtos` 0.3).
+
+> ‼️ The selected logging framework needs to align with the selected framework for the `esp-backtrace` dependency. The `defmt` feature already pulls the matching `esp-backtrace/defmt`, `esp-hal/defmt`, and `esp-radio/defmt` flags for you.
 
 ## Usage Examples
-The repository contains an example folder that contains examples for various device configurations. To run any of the examples enter the following to your command line:
-```bash
-cargo esp32s3 --example <example-name>
-```
-Just replace `example-name` with the file name of any of the examples.
+
+The repository contains an `examples/` folder with configurations for each supported topology. Two flavors of cargo aliases ship in `.cargo/config.toml`:
+
+| Logging | Run alias | Build alias |
+|---|---|---|
+| `println` (default) | `cargo esp32c3 --example <name>` | `cargo esp32c3-build --example <name>` |
+| `defmt` | `cargo esp32c3-defmt --example <name>` | `cargo esp32c3-build-defmt --example <name>` |
+
+Replace `esp32c3` with any of: `esp32`, `esp32c3`, `esp32c5`, `esp32c6`, `esp32s3`. The `-defmt` aliases inject `--features=defmt`, override the espflash runner with `--log-format defmt`, and `build.rs` adds the `-Tdefmt.x` linker script automatically — no manual config edits required to switch between logging backends.
+
+Replace `<name>` with the file name of any example, e.g. `sniffer_wifi`, `esp_now_central`, `wifi_station`.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -87,12 +87,33 @@ esp-generate --chip=esp32c3 your-project
 Add the crate to your `Cargo.toml`. At a minimum, you would need to specify the device and the desired logging framework (`println` or `defmt`):
 
 ```toml
+[dependencies]
 esp-csi-rs = { version = "0.5.2", features = ["esp32c3", "println"] }
 ```
 
 The crate uses Rust **edition 2024** and tracks the latest Espressif Rust ecosystem (`esp-hal` 1.1, `esp-radio` 0.18, `esp-rtos` 0.3).
 
 > ‼️ The selected logging framework needs to align with the selected framework for the `esp-backtrace` dependency. The `defmt` feature already pulls the matching `esp-backtrace/defmt`, `esp-hal/defmt`, and `esp-radio/defmt` flags for you.
+
+### Using `defmt` from your application
+
+When enabling the `defmt` feature, the user app needs three additional things on top of the crate dep:
+
+1. **Add `defmt` as a direct dependency** in your own `Cargo.toml`. Our `log_ln!` macro expands to `defmt::println!(...)` at the call site, so the `defmt` crate must be resolvable from your code. Plain `defmt = "1.0"` is enough — do **not** add `defmt-rtt` or any other logger; we already provide one via `esp-println/defmt-espflash`.
+2. **Add `-Tdefmt.x` to your linker flags** in your own `.cargo/config.toml` (Cargo doesn't propagate linker args from dependencies' build scripts):
+   ```toml
+   [target.'cfg(target_arch = "riscv32")']
+   rustflags = ["-C", "link-arg=-Tlinkall.x", "-C", "link-arg=-Tdefmt.x"]
+   ```
+3. **Decode with espflash**: `espflash flash --monitor --log-format defmt <elf>`. No probe-rs / J-Link needed — frames stream over the same USB-Serial-JTAG channel as `println!`.
+
+```toml
+[dependencies]
+esp-csi-rs = { version = "0.5.2", features = ["esp32c3", "defmt"] }
+defmt = "1.0"
+```
+
+If you're cribbing from this repo's examples, you don't need any of the above — the in-repo `.cargo/config.toml` aliases (`cargo esp32c3-defmt`, etc.) and `build.rs` handle all three steps automatically.
 
 ## Usage Examples
 

--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,12 @@ fn main() {
     println!("cargo:rerun-if-env-changed=MONITOR_BAUD");
     let baud = std::env::var("MONITOR_BAUD").unwrap_or_else(|_| "115200".to_string());
     println!("cargo:rustc-env=UART_LOG_BAUDRATE={}", baud);
+
+    // Pull in the defmt linker script only when the `defmt` feature is on.
+    // Keeps println-only builds free of the defmt symbol table & sections.
+    if std::env::var("CARGO_FEATURE_DEFMT").is_ok() {
+        println!("cargo:rustc-link-arg=-Tdefmt.x");
+    }
 }
 
 #[allow(dead_code)]

--- a/examples/csi_callback_test.rs
+++ b/examples/csi_callback_test.rs
@@ -49,10 +49,7 @@ use esp_csi_rs::{
 };
 use esp_hal::clock::CpuClock;
 use esp_hal::timer::timg::TimerGroup;
-use esp_radio::{
-    wifi::{PowerSaveMode, WifiController},
-    Controller,
-};
+use esp_radio::wifi::WifiController;
 use portable_atomic::{AtomicI32, AtomicU32, AtomicU64};
 use {esp_backtrace as _, esp_println as _};
 
@@ -203,27 +200,16 @@ async fn main(spawner: Spawner) -> ! {
     esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 61440);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    #[cfg(any(feature = "esp32c6", feature = "esp32c3"))]
-    {
-        let sw_interrupt =
-            esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
-        esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
-    }
-    #[cfg(not(any(feature = "esp32c6", feature = "esp32c3")))]
-    esp_rtos::start(timg0.timer0);
+    let sw_interrupt =
+        esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+    esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
 
     log_ln!("Embassy initialized!");
     log_ln!("Starting CSI callback test (sniffer mode)");
 
-    let radio_init = mk_static!(
-        Controller<'static>,
-        esp_radio::init().expect("Failed to initialize Wi-Fi/BLE controller")
-    );
-
-    let config_radio =
-        esp_radio::wifi::Config::default().with_power_save_mode(PowerSaveMode::None);
+    let config_radio = esp_radio::wifi::ControllerConfig::default();
     let (wifi_controller, mut interfaces) =
-        esp_radio::wifi::new(radio_init, peripherals.WIFI, config_radio)
+        esp_radio::wifi::new(peripherals.WIFI, config_radio)
             .expect("Failed to initialize Wi-Fi controller");
 
     let controller = WIFI_CONTROLLER.init(wifi_controller);
@@ -239,7 +225,7 @@ async fn main(spawner: Spawner) -> ! {
         Some(1000),
         csi_hardware,
     );
-    node.set_protocol(esp_radio::wifi::Protocol::P802D11BGNLR);
+    node.set_protocol(esp_radio::wifi::Protocol::LR);
     node.set_rate(esp_radio::esp_now::WifiPhyRate::RateMcs0Lgi);
 
     // Register the inline CSI processing hook. `set_csi_callback`

--- a/examples/esp_now_central.rs
+++ b/examples/esp_now_central.rs
@@ -17,8 +17,7 @@ use esp_csi_rs::{
 };
 use esp_hal::clock::CpuClock;
 use esp_hal::timer::timg::TimerGroup;
-use esp_radio::wifi::PowerSaveMode;
-use esp_radio::{wifi::WifiController, Controller};
+use esp_radio::wifi::WifiController;
 use {esp_backtrace as _, esp_println as _};
 
 extern crate alloc;
@@ -107,26 +106,16 @@ async fn main(spawner: Spawner) -> ! {
     esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 61440);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    #[cfg(any(feature = "esp32c6", feature = "esp32c3"))]
-    {
-        let sw_interrupt =
-            esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
-        esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
-    }
-    #[cfg(not(any(feature = "esp32c6", feature = "esp32c3")))]
-    esp_rtos::start(timg0.timer0);
+    let sw_interrupt =
+        esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+    esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
 
     log_ln!("Embassy initialized!");
     log_ln!("Starting EspNow Central Node");
 
-    let radio_init = mk_static!(
-        Controller<'static>,
-        esp_radio::init().expect("Failed to initialize Wi-Fi/BLE controller")
-    );
-
-    let config_radio = esp_radio::wifi::Config::default().with_power_save_mode(PowerSaveMode::None);
+    let config_radio = esp_radio::wifi::ControllerConfig::default();
     let (wifi_controller, mut interfaces) =
-        esp_radio::wifi::new(radio_init, peripherals.WIFI, config_radio)
+        esp_radio::wifi::new(peripherals.WIFI, config_radio)
             .expect("Failed to initialize Wi-Fi controller");
 
     let controller = WIFI_CONTROLLER.init(wifi_controller);
@@ -134,14 +123,14 @@ async fn main(spawner: Spawner) -> ! {
     let mut node_handle = CSINodeClient::new();
     let csi_hardware = CSINodeHardware::new(&mut interfaces, controller);
     let mut node = CSINode::new(
-        esp_csi_rs::Node::Central(esp_csi_rs::CentralOpMode::EspNow(EspNowConfig::default())),
+        esp_csi_rs::Node::Central(esp_csi_rs::CentralOpMode::EspNow(EspNowConfig::default().with_channel(7))),
         CollectionMode::Collector,
         Some(CsiConfig::default()),
-        Some(10000),
+        Some(1000),
         csi_hardware,
     );
-    node.set_protocol(esp_radio::wifi::Protocol::P802D11BGN);
-    node.set_rate(esp_radio::esp_now::WifiPhyRate::RateMcs7Sgi);
+    node.set_protocol(esp_radio::wifi::Protocol::N);
+    node.set_rate(esp_radio::esp_now::WifiPhyRate::RateMcs0Lgi);
 
     set_csi_callback(on_csi);
     let _ = &mut node_handle;

--- a/examples/esp_now_central_exper.rs
+++ b/examples/esp_now_central_exper.rs
@@ -13,7 +13,7 @@ use esp_csi_rs::{
 };
 use esp_hal::clock::CpuClock;
 use esp_hal::timer::timg::TimerGroup;
-use esp_radio::{wifi::WifiController, Controller};
+use esp_radio::wifi::WifiController;
 use {esp_backtrace as _, esp_println as _};
 
 extern crate alloc;
@@ -73,31 +73,20 @@ async fn main(spawner: Spawner) -> ! {
     esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 98440);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    #[cfg(any(feature = "esp32c6", feature = "esp32c3"))]
-    {
-        let sw_interrupt =
-            esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
-        esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
-    }
-    #[cfg(not(any(feature = "esp32c6", feature = "esp32c3")))]
-    esp_rtos::start(timg0.timer0);
+    let sw_interrupt =
+        esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+    esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
 
     log_ln!("Embassy initialized!");
     log_ln!("Starting EspNow Central Node (Exper)");
 
-    let radio_init = mk_static!(
-        Controller<'static>,
-        esp_radio::init().expect("Failed to initialize Wi-Fi/BLE controller")
-    );
-
-    let config_radio = esp_radio::wifi::Config::default()
-        .with_power_save_mode(esp_radio::wifi::PowerSaveMode::None)
+    let config_radio = esp_radio::wifi::ControllerConfig::default()
         .with_static_tx_buf_num(25)
         .with_dynamic_tx_buf_num(128)
         .with_ampdu_tx_enable(false).
         with_tx_queue_size(32);
     let (wifi_controller, mut interfaces) =
-        esp_radio::wifi::new(radio_init, peripherals.WIFI, config_radio)
+        esp_radio::wifi::new(peripherals.WIFI, config_radio)
             .expect("Failed to initialize Wi-Fi controller");
 
     let controller = WIFI_CONTROLLER.init(wifi_controller);
@@ -111,7 +100,7 @@ async fn main(spawner: Spawner) -> ! {
         Some(10000),
         csi_hardware,
     );
-    node.set_protocol(esp_radio::wifi::Protocol::P802D11BGN);
+    node.set_protocol(esp_radio::wifi::Protocol::N);
     node.set_rx_enabled(false);
     node.set_rate(esp_radio::esp_now::WifiPhyRate::RateMcs0Lgi);
 

--- a/examples/esp_now_peripheral.rs
+++ b/examples/esp_now_peripheral.rs
@@ -17,8 +17,7 @@ use esp_csi_rs::{
 };
 use esp_hal::clock::CpuClock;
 use esp_hal::timer::timg::TimerGroup;
-use esp_radio::wifi::PowerSaveMode;
-use esp_radio::{wifi::WifiController, Controller};
+use esp_radio::wifi::WifiController;
 use {esp_backtrace as _, esp_println as _};
 
 extern crate alloc;
@@ -114,26 +113,16 @@ async fn main(spawner: Spawner) -> ! {
     esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 98440);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    #[cfg(any(feature = "esp32c6", feature = "esp32c3"))]
-    {
-        let sw_interrupt =
-            esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
-        esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
-    }
-    #[cfg(not(any(feature = "esp32c6", feature = "esp32c3")))]
-    esp_rtos::start(timg0.timer0);
+    let sw_interrupt =
+        esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+    esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
 
     log_ln!("Embassy initialized!");
     log_ln!("Starting EspNow Peripheral Node");
 
-    let radio_init = mk_static!(
-        Controller<'static>,
-        esp_radio::init().expect("Failed to initialize Wi-Fi/BLE controller")
-    );
-
-    let config_radio = esp_radio::wifi::Config::default().with_power_save_mode(PowerSaveMode::None);
+    let config_radio = esp_radio::wifi::ControllerConfig::default();
     let (wifi_controller, mut interfaces) =
-        esp_radio::wifi::new(radio_init, peripherals.WIFI, config_radio)
+        esp_radio::wifi::new(peripherals.WIFI, config_radio)
             .expect("Failed to initialize Wi-Fi controller");
 
     let controller = WIFI_CONTROLLER.init(wifi_controller);
@@ -149,7 +138,7 @@ async fn main(spawner: Spawner) -> ! {
         Some(1000),
         csi_hardware,
     );
-    node.set_protocol(esp_radio::wifi::Protocol::P802D11BGN);
+    node.set_protocol(esp_radio::wifi::Protocol::N);
     node.set_rate(esp_radio::esp_now::WifiPhyRate::RateMcs0Lgi);
 
     set_csi_callback(on_csi);

--- a/examples/esp_now_peripheral_exper.rs
+++ b/examples/esp_now_peripheral_exper.rs
@@ -11,7 +11,7 @@ use esp_csi_rs::{
 use esp_csi_rs::{CSINodeClient, CSINodeHardware, get_total_rx_packets, log_ln, set_csi_logging_enabled};
 use esp_hal::clock::CpuClock;
 use esp_hal::timer::timg::TimerGroup;
-use esp_radio::{wifi::WifiController, Controller};
+use esp_radio::wifi::WifiController;
 use {esp_backtrace as _, esp_println as _};
 
 extern crate alloc;
@@ -63,32 +63,21 @@ async fn main(spawner: Spawner) -> ! {
     esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 98440);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    #[cfg(any(feature = "esp32c6", feature = "esp32c3"))]
-    {
-        let sw_interrupt =
-            esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
-        esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
-    }
-    #[cfg(not(any(feature = "esp32c6", feature = "esp32c3")))]
-    esp_rtos::start(timg0.timer0);
+    let sw_interrupt =
+        esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+    esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
 
     log_ln!("Embassy initialized!");
     log_ln!("Starting EspNow Peripheral Node (Exper)");
 
-    let radio_init = mk_static!(
-        Controller<'static>,
-        esp_radio::init().expect("Failed to initialize Wi-Fi/BLE controller")
-    );
-
     // Raise Wi-Fi buffer budget for sustained ESP-NOW + CSI traffic.
-    let config_radio = esp_radio::wifi::Config::default()
-        .with_power_save_mode(esp_radio::wifi::PowerSaveMode::None)
+    let config_radio = esp_radio::wifi::ControllerConfig::default()
         .with_static_rx_buf_num(25)
         .with_dynamic_rx_buf_num(128)
         .with_ampdu_rx_enable(false)
         .with_rx_queue_size(32);
     let (wifi_controller, mut interfaces) =
-        esp_radio::wifi::new(radio_init, peripherals.WIFI, config_radio)
+        esp_radio::wifi::new(peripherals.WIFI, config_radio)
             .expect("Failed to initialize Wi-Fi controller");
 
     let controller = WIFI_CONTROLLER.init(wifi_controller);
@@ -104,7 +93,7 @@ async fn main(spawner: Spawner) -> ! {
         Some(10000),
         csi_hardware,
     );
-    node.set_protocol(esp_radio::wifi::Protocol::P802D11BGN);
+    node.set_protocol(esp_radio::wifi::Protocol::N);
     node.set_tx_enabled(false);
 
     join(node.run(), node_task(&mut node_handle)).await;

--- a/examples/esp_now_peripheral_no_stats.rs
+++ b/examples/esp_now_peripheral_no_stats.rs
@@ -10,7 +10,7 @@ use esp_csi_rs::{
 use esp_csi_rs::{log_ln, CSINodeClient, CSINodeHardware};
 use esp_hal::clock::CpuClock;
 use esp_hal::timer::timg::TimerGroup;
-use esp_radio::{wifi::WifiController, Controller};
+use esp_radio::wifi::WifiController;
 use {esp_backtrace as _, esp_println as _};
 
 extern crate alloc;
@@ -47,26 +47,15 @@ async fn main(spawner: Spawner) -> ! {
     esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 98440);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    #[cfg(any(feature = "esp32c6", feature = "esp32c3"))]
-    {
-        let sw_interrupt =
-            esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
-        esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
-    }
-    #[cfg(not(any(feature = "esp32c6", feature = "esp32c3")))]
-    esp_rtos::start(timg0.timer0);
+    let sw_interrupt =
+        esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+    esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
 
     log_ln!("Embassy initialized!");
     log_ln!("Starting EspNow Peripheral Node");
 
-    let radio_init = mk_static!(
-        Controller<'static>,
-        esp_radio::init().expect("Failed to initialize Wi-Fi/BLE controller")
-    );
-
     // Raise Wi-Fi buffer budget for sustained ESP-NOW + CSI traffic.
-    let config_radio = esp_radio::wifi::Config::default()
-        .with_power_save_mode(esp_radio::wifi::PowerSaveMode::None)
+    let config_radio = esp_radio::wifi::ControllerConfig::default()
         .with_static_rx_buf_num(32)
         .with_dynamic_rx_buf_num(64)
         .with_static_tx_buf_num(32)
@@ -77,7 +66,7 @@ async fn main(spawner: Spawner) -> ! {
         .with_ampdu_tx_enable(true)
         .with_rx_ba_win(16);
     let (wifi_controller, mut interfaces) =
-        esp_radio::wifi::new(radio_init, peripherals.WIFI, config_radio)
+        esp_radio::wifi::new(peripherals.WIFI, config_radio)
             .expect("Failed to initialize Wi-Fi controller");
 
     let controller = WIFI_CONTROLLER.init(wifi_controller);
@@ -93,7 +82,7 @@ async fn main(spawner: Spawner) -> ! {
         Some(1500),
         csi_hardware,
     );
-    node.set_protocol(esp_radio::wifi::Protocol::P802D11BGN);
+    node.set_protocol(esp_radio::wifi::Protocol::N);
     node.set_rate(esp_radio::esp_now::WifiPhyRate::RateMcs3Lgi);
 
     node.run().await;

--- a/examples/runtime_config.rs
+++ b/examples/runtime_config.rs
@@ -14,7 +14,7 @@ use esp_csi_rs::{
 };
 use esp_hal::clock::CpuClock;
 use esp_hal::timer::timg::TimerGroup;
-use esp_radio::{wifi::WifiController, Controller};
+use esp_radio::wifi::WifiController;
 use {esp_backtrace as _, esp_println as _};
 
 extern crate alloc;
@@ -85,27 +85,16 @@ async fn main(spawner: Spawner) -> ! {
     esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 61440);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    #[cfg(any(feature = "esp32c6", feature = "esp32c3"))]
-    {
-        let sw_interrupt =
-            esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
-        esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
-    }
-    #[cfg(not(any(feature = "esp32c6", feature = "esp32c3")))]
-    esp_rtos::start(timg0.timer0);
+    let sw_interrupt =
+        esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+    esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
 
     log_ln!("Embassy initialized!");
     log_ln!("Starting Runtime Config Node");
 
-    let radio_init = mk_static!(
-        Controller<'static>,
-        esp_radio::init().expect("Failed to initialize Wi-Fi/BLE controller")
-    );
-
-    let config_radio = esp_radio::wifi::Config::default()
-        .with_power_save_mode(esp_radio::wifi::PowerSaveMode::None);
+    let config_radio = esp_radio::wifi::ControllerConfig::default();
     let (wifi_controller, mut interfaces) =
-        esp_radio::wifi::new(radio_init, peripherals.WIFI, config_radio)
+        esp_radio::wifi::new(peripherals.WIFI, config_radio)
             .expect("Failed to initialize Wi-Fi controller");
 
     let controller = WIFI_CONTROLLER.init(wifi_controller);
@@ -121,7 +110,7 @@ async fn main(spawner: Spawner) -> ! {
         Some(1000),
         csi_hardware,
     );
-    node.set_protocol(esp_radio::wifi::Protocol::P802D11BGNLR);
+    node.set_protocol(esp_radio::wifi::Protocol::LR);
     node.set_rate(esp_radio::esp_now::WifiPhyRate::RateMcs0Lgi);
     
     join(node.run(), node_task_collector(&mut node_handle)).await;

--- a/examples/sniffer_wifi.rs
+++ b/examples/sniffer_wifi.rs
@@ -3,6 +3,7 @@
 
 use portable_atomic::{AtomicI32, AtomicU32, Ordering};
 use embassy_executor::Spawner;
+use embassy_futures::join::join;
 use embassy_time::{Duration, Timer};
 use esp_csi_rs::csi::CSIDataPacket;
 use esp_csi_rs::logging::logging::LogMode;
@@ -12,10 +13,7 @@ use esp_csi_rs::{
 };
 use esp_hal::clock::CpuClock;
 use esp_hal::timer::timg::TimerGroup;
-use esp_radio::{
-    wifi::{PowerSaveMode, WifiController},
-    Controller,
-};
+use esp_radio::wifi::WifiController;
 use {esp_backtrace as _, esp_println as _};
 
 extern crate alloc;
@@ -23,8 +21,6 @@ extern crate alloc;
 static WIFI_CONTROLLER: static_cell::StaticCell<WifiController<'static>> =
     static_cell::StaticCell::new();
 
-// This creates a default app-descriptor required by the esp-idf bootloader.
-// For more information see: <https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/app_image_format.html#application-description>
 esp_bootloader_esp_idf::esp_app_desc!();
 
 #[allow(
@@ -41,50 +37,50 @@ macro_rules! mk_static {
     }};
 }
 
-// Shared state written by the inline CSI callback. A typical sniffer
-// application processes packets in this hook (e.g. compute statistics,
-// extract subcarriers, run a model) without spawning a consumer task.
+// Shared state written by the inline CSI callback and read by `stats_task`.
 static LATEST_RSSI: AtomicI32 = AtomicI32::new(0);
 static CSI_PKT_COUNT: AtomicU32 = AtomicU32::new(0);
 
-// On-device CSI processing hook. Runs inline in the WiFi callback — keep
-// it fast: no heap allocation, no locking, no blocking I/O.
 fn on_csi(packet: &CSIDataPacket) {
     LATEST_RSSI.store(packet.rssi as i32, Ordering::Relaxed);
     CSI_PKT_COUNT.fetch_add(1, Ordering::Relaxed);
 }
 
+async fn stats_task() {
+    let mut last_count = 0u32;
+    loop {
+        Timer::after_secs(1).await;
+        let total = CSI_PKT_COUNT.load(Ordering::Relaxed);
+        let delta = total.wrapping_sub(last_count);
+        last_count = total;
+        log_ln!(
+            "CSI rate: {}/s, total: {}, last RSSI: {}",
+            delta,
+            total,
+            LATEST_RSSI.load(Ordering::Relaxed),
+        )
+    }
+}
+
 #[esp_rtos::main]
 async fn main(spawner: Spawner) -> ! {
-    // generator version: 1.1.0
-
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
-    init_logger(spawner, LogMode::ArrayList);
+    init_logger(spawner, LogMode::Text);
 
     esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 61440);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    #[cfg(any(feature = "esp32c6", feature = "esp32c3"))]
-    {
-        let sw_interrupt =
-            esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
-        esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
-    }
-    #[cfg(not(any(feature = "esp32c6", feature = "esp32c3")))]
-    esp_rtos::start(timg0.timer0);
+    let sw_interrupt =
+        esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+    esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
 
     log_ln!("Embassy initialized!");
     log_ln!("Starting Wi-Fi Sniffer Peripheral Node");
 
-    let radio_init = mk_static!(
-        Controller<'static>,
-        esp_radio::init().expect("Failed to initialize Wi-Fi/BLE controller")
-    );
-
-    let config_radio = esp_radio::wifi::Config::default().with_power_save_mode(PowerSaveMode::None);
+    let config_radio = esp_radio::wifi::ControllerConfig::default();
     let (wifi_controller, mut interfaces) =
-        esp_radio::wifi::new(radio_init, peripherals.WIFI, config_radio)
+        esp_radio::wifi::new(peripherals.WIFI, config_radio)
             .expect("Failed to initialize Wi-Fi controller");
 
     let controller = WIFI_CONTROLLER.init(wifi_controller);
@@ -93,32 +89,22 @@ async fn main(spawner: Spawner) -> ! {
     let csi_hardware = CSINodeHardware::new(&mut interfaces, controller);
     let mut node = CSINode::new(
         esp_csi_rs::Node::Peripheral(esp_csi_rs::PeripheralOpMode::WifiSniffer(
-            WifiSnifferConfig::default(),
+            WifiSnifferConfig::default().with_channel(7),
         )),
         CollectionMode::Collector,
         Some(CsiConfig::default()),
-        Some(1000),
+        Some(10000),
         csi_hardware,
     );
-    node.set_protocol(esp_radio::wifi::Protocol::P802D11BGNLR);
-    node.set_rate(esp_radio::esp_now::WifiPhyRate::RateMcs0Lgi);
 
-    // Register the on-device CSI processing hook before starting the node.
-    // Each sniffed CSI report invokes `on_csi` inline in the WiFi callback.
+    node.set_protocol(esp_radio::wifi::Protocol::N);
+
     set_csi_callback(on_csi);
-
-    node.run_duration(1000, &mut node_handle).await;
-
-    log_ln!(
-        "Sniffer stopped. Total CSI packets: {}, Last observed RSSI: {}",
-        CSI_PKT_COUNT.load(Ordering::Relaxed),
-        LATEST_RSSI.load(Ordering::Relaxed),
-    );
+    let _ = &mut node_handle;
+    join(node.run(), stats_task()).await;
 
     loop {
         log_ln!("Hello world!");
         Timer::after(Duration::from_secs(1)).await;
     }
-
-    // for inspiration have a look at the examples at https://github.com/esp-rs/esp-hal/tree/esp-hal-v~1.0/examples
 }

--- a/examples/sniffer_wifi_exper.rs
+++ b/examples/sniffer_wifi_exper.rs
@@ -11,7 +11,7 @@ use esp_csi_rs::{
 };
 use esp_hal::clock::CpuClock;
 use esp_hal::timer::timg::TimerGroup;
-use esp_radio::{wifi::WifiController, Controller};
+use esp_radio::wifi::WifiController;
 use {esp_backtrace as _, esp_println as _};
 
 extern crate alloc;
@@ -70,31 +70,19 @@ async fn main(spawner: Spawner) -> ! {
     esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 98440);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    #[cfg(any(feature = "esp32c6", feature = "esp32c3"))]
-    {
-        let sw_interrupt =
-            esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
-        esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
-    }
-    #[cfg(not(any(feature = "esp32c6", feature = "esp32c3")))]
-    esp_rtos::start(timg0.timer0);
+    let sw_interrupt =
+        esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+    esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
 
     log_ln!("Embassy initialized!");
     log_ln!("Starting Wi-Fi Sniffer Peripheral Node (Exper)");
 
-    let radio_init = mk_static!(
-        Controller<'static>,
-        esp_radio::init().expect("Failed to initialize Wi-Fi/BLE controller")
-    );
-
-    let mut config_radio = esp_radio::wifi::Config::default();
-    config_radio = config_radio
-        .with_power_save_mode(esp_radio::wifi::PowerSaveMode::None)
+    let config_radio = esp_radio::wifi::ControllerConfig::default()
         .with_static_rx_buf_num(32)
         .with_dynamic_rx_buf_num(128)
         .with_rx_queue_size(32);
     let (wifi_controller, mut interfaces) =
-        esp_radio::wifi::new(radio_init, peripherals.WIFI, config_radio)
+        esp_radio::wifi::new(peripherals.WIFI, config_radio)
             .expect("Failed to initialize Wi-Fi controller");
 
     let controller = WIFI_CONTROLLER.init(wifi_controller);
@@ -110,7 +98,7 @@ async fn main(spawner: Spawner) -> ! {
         Some(10000),
         csi_hardware,
     );
-    node.set_protocol(esp_radio::wifi::Protocol::P802D11BGN);
+    node.set_protocol(esp_radio::wifi::Protocol::N);
 
     join(node.run(), node_task(&mut node_handle)).await;
 

--- a/examples/wifi_station.rs
+++ b/examples/wifi_station.rs
@@ -16,10 +16,8 @@ use esp_csi_rs::{
 };
 use esp_hal::clock::CpuClock;
 use esp_hal::timer::timg::TimerGroup;
-use esp_radio::{
-    wifi::{ClientConfig, WifiController},
-    Controller,
-};
+use esp_radio::wifi::sta::StationConfig;
+use esp_radio::wifi::WifiController;
 use {esp_backtrace as _, esp_println as _};
 
 extern crate alloc;
@@ -88,37 +86,24 @@ async fn main(spawner: Spawner) -> ! {
     esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 61440);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    #[cfg(any(feature = "esp32c6", feature = "esp32c3"))]
-    {
-        let sw_interrupt =
-            esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
-        esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
-    }
-    #[cfg(not(any(feature = "esp32c6", feature = "esp32c3")))]
-    esp_rtos::start(timg0.timer0);
+    let sw_interrupt =
+        esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+    esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
 
     log_ln!("Embassy initialized!");
     log_ln!("Starting Wifi Station Node");
 
-    let radio_init = mk_static!(
-        Controller<'static>,
-        esp_radio::init().expect("Failed to initialize Wi-Fi/BLE controller")
-    );
-
-    let mut config_radio = esp_radio::wifi::Config::default().with_power_save_mode(esp_radio::wifi::PowerSaveMode::None);
-    // Raise Wi-Fi buffer budget for sustained ESP-NOW + CSI traffic.
-    config_radio = config_radio
-        .with_power_save_mode(esp_radio::wifi::PowerSaveMode::None);
+    let config_radio = esp_radio::wifi::ControllerConfig::default();
     let (wifi_controller, mut interfaces) =
-        esp_radio::wifi::new(radio_init, peripherals.WIFI, config_radio)
+        esp_radio::wifi::new(peripherals.WIFI, config_radio)
             .expect("Failed to initialize Wi-Fi controller");
 
     let controller = WIFI_CONTROLLER.init(wifi_controller);
 
-    let client_config = ClientConfig::default()
-        .with_ssid("SSID".to_string())
-        .with_password("PASS".to_string())
-        .with_auth_method(esp_radio::wifi::AuthMethod::Wpa2Personal);
+    let client_config = StationConfig::default()
+        .with_ssid("SSID")
+        .with_password("PASS@".to_string())
+        .with_auth_method(esp_radio::wifi::AuthenticationMethod::Wpa2Personal);
 
     let station_config = WifiStationConfig {
         client_config, // Pass the config we created above
@@ -136,9 +121,9 @@ async fn main(spawner: Spawner) -> ! {
         csi_hardware,
     );
     #[cfg(feature = "esp32c6")]
-    node.set_protocol(esp_radio::wifi::Protocol::P802D11BGNAX);
+    node.set_protocol(esp_radio::wifi::Protocol::AX);
     #[cfg(not(feature = "esp32c6"))]
-    node.set_protocol(esp_radio::wifi::Protocol::P802D11BGN);
+    node.set_protocol(esp_radio::wifi::Protocol::N);
 
     // Register the on-device CSI processing hook. Runs inline in the WiFi
     // callback for every CSI packet — also implicitly enables the publish

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,6 +4,6 @@ channel = "esp"
 # channel = "stable"
 # components = ["rust-src"]
 # targets = [
-#     "riscv32imc-unknown-none-elf",  # ESP32-C2, ESP32-C3
+#     "riscv32imc-unknown-none-elf",  # ESP32-C3
 #     "riscv32imac-unknown-none-elf", # ESP32-C6, ESP32-H2
 # ]

--- a/src/lib/central/esp_now.rs
+++ b/src/lib/central/esp_now.rs
@@ -6,6 +6,7 @@
 //! and pushes results into the runtime statistics channel when the
 //! `statistics` feature is enabled.
 
+#[cfg(feature = "statistics")]
 use core::sync::atomic::Ordering;
 
 use embassy_futures::select::{select, Either};
@@ -86,7 +87,7 @@ fn handle_peripheral_packet(
     esp_now: &mut EspNow<'static>,
     r: PoolFrame,
     channel: u8,
-    latency_offset: &mut i64,
+    #[cfg_attr(not(feature = "statistics"), allow(unused_variables))] latency_offset: &mut i64,
     known_peers: &mut LinearMap<[u8; 6], (), RX_TRACKED_PEERS_CAPACITY>,
 ) {
     #[cfg(feature = "statistics")]
@@ -103,7 +104,7 @@ fn handle_peripheral_packet(
     if known_peers.get(&r.info.src_address).is_none() {
         if !esp_now.peer_exists(&r.info.src_address) {
             let _ = esp_now.add_peer(PeerInfo {
-                interface: esp_radio::esp_now::EspNowWifiInterface::Sta,
+                interface: esp_radio::esp_now::EspNowWifiInterface::Station,
                 peer_address: r.info.src_address,
                 lmk: None,
                 channel: Some(channel),

--- a/src/lib/central/sta.rs
+++ b/src/lib/central/sta.rs
@@ -11,8 +11,8 @@ use embassy_futures::select::{select, select3, Either, Either3};
 use embassy_net::raw::{IpProtocol, IpVersion, PacketMetadata, RawSocket};
 use embassy_net::{Ipv4Address, Ipv4Cidr, Runner, Stack, StackResources};
 use embassy_time::{with_timeout, Duration, Timer};
-use enumset::enum_set;
-use esp_radio::wifi::{CsiConfig, ModeConfig, WifiController, WifiDevice, WifiEvent};
+use esp_radio::wifi::csi::CsiConfig;
+use esp_radio::wifi::{Config, Interface, WifiController};
 use smoltcp::phy::ChecksumCapabilities;
 
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
@@ -42,10 +42,10 @@ struct IpInfo {
 
 /// Initialize the station interface and return the network stack and runner.
 pub fn sta_init<'a>(
-    interfaces: &'a mut WifiDevice<'static>,
+    interfaces: &'a mut Interface<'static>,
     config: &WifiStationConfig,
     controller: &mut WifiController<'static>,
-) -> (Stack<'a>, Runner<'a, &'a mut WifiDevice<'static>>) {
+) -> (Stack<'a>, Runner<'a, &'a mut Interface<'static>>) {
     let sta_ip_config = embassy_net::Config::dhcpv4(Default::default());
     let seed = 123456_u64;
 
@@ -58,7 +58,7 @@ pub fn sta_init<'a>(
     );
 
     // Configure WiFi Client/Station Connection
-    let station_config = ModeConfig::Client(config.client_config.clone());
+    let station_config = Config::Station(config.client_config.clone());
     // Set the Configuration
     match controller.set_config(&station_config) {
         Ok(_) => log_ln!("WiFi Configuration Set: {:?}", config),
@@ -76,7 +76,7 @@ pub async fn run_sta_connect(
     controller: &mut WifiController<'_>,
     freq: Option<u16>,
     sta_stack: Stack<'_>,
-    sta_runner: Runner<'_, &mut WifiDevice<'_>>,
+    sta_runner: Runner<'_, &mut Interface<'_>>,
     csi_config: CsiConfig,
     io_tasks: IOTaskConfig,
 ) {
@@ -134,20 +134,16 @@ pub async fn run_sta_connect(
 
         if consecutive_failures >= FAILURES_BEFORE_RADIO_CYCLE {
             log_ln!(
-                "Cycling Wi-Fi controller after {} failures (last: {}) to clear stale state",
+                "Cycling Wi-Fi controller after {} failures (last: {}) to clear stale state (kind: {})",
                 consecutive_failures,
+                failure_kind,
                 failure_kind
             );
-            let _ = controller.stop_async().await;
+            // esp-radio 0.18 removed start_async/stop_async; reapply CSI filter
+            // directly to clear any controller state that wedged after the
+            // failed connect attempt.
+            set_csi(controller, csi_config.clone());
             Timer::after(Duration::from_millis(300)).await;
-            match controller.start_async().await {
-                Ok(()) => {
-                    // Controller stop clears CSI filter/callback state; re-apply
-                    // before the next connect attempt so CSI keeps working.
-                    set_csi(controller, csi_config.clone());
-                }
-                Err(e) => log_ln!("Controller restart failed: {:?}", e),
-            }
             consecutive_failures = 0;
         }
 
@@ -179,7 +175,7 @@ pub async fn run_sta_connect(
 }
 
 /// Run the embassy-net runner until a stop signal is received.
-async fn run_net_task(mut sta_runner: Runner<'_, &mut WifiDevice<'_>>) {
+async fn run_net_task(mut sta_runner: Runner<'_, &mut Interface<'_>>) {
     loop {
         match select(STOP_SIGNAL.wait(), sta_runner.run()).await {
             Either::First(_) => {
@@ -216,8 +212,17 @@ async fn run_dhcp_client(sta_stack: Stack<'_>) {
                 ip_info.local_address = config.address;
                 ip_info.gateway_address = config.gateway.unwrap_or(Ipv4Address::UNSPECIFIED);
 
-                log_ln!("Local IP: {:?}", ip_info.local_address);
-                log_ln!("Gateway IP: {:?}", ip_info.gateway_address);
+                let octets = ip_info.local_address.address().octets();
+                log_ln!(
+                    "Local IP: {}.{}.{}.{}/{}",
+                    octets[0],
+                    octets[1],
+                    octets[2],
+                    octets[3],
+                    ip_info.local_address.prefix_len()
+                );
+                let g = ip_info.gateway_address.octets();
+                log_ln!("Gateway IP: {}.{}.{}.{}", g[0], g[1], g[2], g[3]);
 
                 break;
             }
@@ -237,68 +242,44 @@ async fn run_dhcp_client(sta_stack: Stack<'_>) {
 
 /// Monitor STA events (connect/disconnect/stop) until a stop signal.
 pub async fn sta_connection(controller: &mut WifiController<'_>) {
-    // let mut start_collection_watch = match START_COLLECTION.receiver() {
-    //     Some(r) => r,
-    //     None => panic!("Maximum number of recievers reached"),
-    // };
-
-    // Define Events to Listen for
-    let sta_events =
-        enum_set!(WifiEvent::StaDisconnected | WifiEvent::StaStop | WifiEvent::StaConnected);
-
     // Monitoring/stop loop
     loop {
-        // // Stop Collection Future
-        // let stop_coll_fut = start_collection_watch.changed();
-        // // Events Future
-        // let mut wait_event_fut = controller.wait_for_events(sta_events, true);
-        match select(
-            STOP_SIGNAL.wait(),
-            controller.wait_for_events(sta_events, true),
-        )
-        .await
-        {
+        match select(STOP_SIGNAL.wait(), controller.wait_for_disconnect_async()).await {
             Either::First(_) => {
                 STOP_SIGNAL.signal(());
                 break;
             }
-            Either::Second(mut wait_event_fut) => {
-                if wait_event_fut.contains(WifiEvent::StaDisconnected) {
-                    log_ln!("STA Disconnected");
+            Either::Second(_) => {
+                log_ln!("STA Disconnected");
 
-                    // Try to reconnect until successful or stop requested.
-                    loop {
-                        match select(STOP_SIGNAL.wait(), controller.connect_async()).await {
-                            Either::First(_) => {
-                                STOP_SIGNAL.signal(());
-                                return;
-                            }
-                            Either::Second(Ok(_)) => {
-                                log_ln!("STA Reconnected");
-                                break;
-                            }
-                            Either::Second(Err(e)) => {
-                                log_ln!("STA reconnect failed: {:?}", e);
-                                match select(
-                                    STOP_SIGNAL.wait(),
-                                    Timer::after(Duration::from_secs(1)),
-                                )
-                                .await
-                                {
-                                    Either::First(_) => {
-                                        STOP_SIGNAL.signal(());
-                                        return;
-                                    }
-                                    Either::Second(_) => {}
+                // Try to reconnect until successful or stop requested.
+                loop {
+                    match select(STOP_SIGNAL.wait(), controller.connect_async()).await {
+                        Either::First(_) => {
+                            STOP_SIGNAL.signal(());
+                            return;
+                        }
+                        Either::Second(Ok(_)) => {
+                            log_ln!("STA Reconnected");
+                            break;
+                        }
+                        Either::Second(Err(e)) => {
+                            log_ln!("STA reconnect failed: {:?}", e);
+                            match select(
+                                STOP_SIGNAL.wait(),
+                                Timer::after(Duration::from_secs(1)),
+                            )
+                            .await
+                            {
+                                Either::First(_) => {
+                                    STOP_SIGNAL.signal(());
+                                    return;
                                 }
+                                Either::Second(_) => {}
                             }
                         }
                     }
                 }
-                if wait_event_fut.contains(WifiEvent::StaStop) {
-                    log_ln!("STA Stopped");
-                }
-                wait_event_fut.clear();
             }
         }
     }
@@ -320,7 +301,7 @@ pub async fn sta_network_ops(sta_stack: Stack<'_>, frequency_hz: Option<u16>) {
     let mut rx_meta: [PacketMetadata; 1] = [PacketMetadata::EMPTY; 1];
     let mut tx_meta: [PacketMetadata; 1] = [PacketMetadata::EMPTY; 1];
 
-    let raw_socket = RawSocket::new::<WifiDevice<'_>>(
+    let raw_socket = RawSocket::new::<Interface<'_>>(
         sta_stack,
         IpVersion::Ipv4,
         IpProtocol::Icmp,

--- a/src/lib/config/csi.rs
+++ b/src/lib/config/csi.rs
@@ -1,6 +1,7 @@
 /// CSI Collection Configuration Struct
 #[derive(Debug, Clone)]
-#[cfg(not(feature = "esp32c6"))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg(not(any(feature = "esp32c5", feature = "esp32c6")))]
 pub struct CsiConfig {
     /// Enable to receive legacy long training field(lltf) data.
     pub lltf_en: bool,
@@ -27,6 +28,7 @@ pub struct CsiConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg(feature = "esp32c6")]
 pub struct CsiConfig {
     /// Enable to acquire CSI.
@@ -57,6 +59,42 @@ pub struct CsiConfig {
     pub reserved: u32,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg(feature = "esp32c5")]
+pub struct CsiConfig {
+    /// Enable to acquire CSI.
+    pub enable: u32,
+    /// Enable to acquire L-LTF.
+    pub acquire_csi_legacy: u32,
+    /// Force-acquire L-LTF.
+    pub acquire_csi_force_lltf: bool,
+    /// Enable to acquire HT-LTF when receiving an HT20 PPDU.
+    pub acquire_csi_ht20: u32,
+    /// Enable to acquire HT-LTF when receiving an HT40 PPDU.
+    pub acquire_csi_ht40: u32,
+    /// Enable to acquire VHT-LTF when receiving a VHT20 PPDU.
+    pub acquire_csi_vht: bool,
+    /// Enable to acquire HE-LTF when receiving an HE20 SU PPDU.
+    pub acquire_csi_su: u32,
+    /// Enable to acquire HE-LTF when receiving an HE20 MU PPDU.
+    pub acquire_csi_mu: u32,
+    /// Enable to acquire HE-LTF when receiving an HE20 DCM applied PPDU.
+    pub acquire_csi_dcm: u32,
+    /// Enable to acquire HE-LTF when receiving an HE20 Beamformed applied PPDU.
+    pub acquire_csi_beamformed: u32,
+    /// When receiving an STBC applied HE PPDU, 0- acquire the complete
+    /// HE-LTF1,  1- acquire the complete HE-LTF2, 2- sample evenly among the
+    /// HE-LTF1 and HE-LTF2.
+    pub acquire_csi_he_stbc: u32,
+    /// Value 0-3.
+    pub val_scale_cfg: u32,
+    /// Enable to dump 802.11 ACK frame, default disabled.
+    pub dump_ack_en: u32,
+    /// Reserved.
+    pub reserved: u32,
+}
+
 impl Default for CsiConfig {
     /// Default implmentation for CSI Collection Configuration:
     /// - lltf is enabled
@@ -67,7 +105,7 @@ impl Default for CsiConfig {
     /// - manu scale is disabled
     /// - no bit shift
     /// - 802.11 ack frame dump disabled
-    #[cfg(not(feature = "esp32c6"))]
+    #[cfg(not(any(feature = "esp32c5", feature = "esp32c6")))]
     fn default() -> Self {
         Self {
             lltf_en: true,
@@ -96,6 +134,26 @@ impl Default for CsiConfig {
             val_scale_cfg: 2,
             dump_ack_en: 1,
             reserved: 19,
+        }
+    }
+    // ESP32-C5 (mac_version 3) — adds force_lltf and vht fields.
+    #[cfg(feature = "esp32c5")]
+    fn default() -> Self {
+        Self {
+            enable: 1,
+            acquire_csi_legacy: 1,
+            acquire_csi_force_lltf: true,
+            acquire_csi_ht20: 1,
+            acquire_csi_ht40: 1,
+            acquire_csi_vht: true,
+            acquire_csi_su: 1,
+            acquire_csi_mu: 1,
+            acquire_csi_dcm: 1,
+            acquire_csi_beamformed: 1,
+            acquire_csi_he_stbc: 2,
+            val_scale_cfg: 2,
+            dump_ack_en: 1,
+            reserved: 0,
         }
     }
 }

--- a/src/lib/csi.rs
+++ b/src/lib/csi.rs
@@ -93,7 +93,7 @@ pub enum RxCSIFmt {
 // rxmatch0: Indicate whether the reception frame is from interface 0.
 
 /// CSI Received Packet w/ Radio Metadata
-#[cfg(not(feature = "esp32c6"))]
+#[cfg(not(any(feature = "esp32c5", feature = "esp32c6")))]
 #[derive(Debug, Clone, Serialize, Deserialize, MaxSize)]
 pub struct CSIDataPacket {
     /// MAC address of the sender.
@@ -162,7 +162,7 @@ pub struct CSIDataPacket {
     pub csi_data: Vec<i8, 612>,
 }
 
-#[cfg(not(feature = "esp32c6"))]
+#[cfg(not(any(feature = "esp32c5", feature = "esp32c6")))]
 impl CSIDataPacket {
     /// Prints Recieved CSI Data Packet with it's Metadata.
     ///
@@ -390,7 +390,7 @@ impl CSIDataPacket {
     }
 }
 
-#[cfg(feature = "esp32c6")]
+#[cfg(any(feature = "esp32c5", feature = "esp32c6"))]
 #[derive(Debug, Clone, Serialize, Deserialize, MaxSize)]
 pub struct CSIDataPacket {
     /// MAC address of the sender.
@@ -412,8 +412,10 @@ pub struct CSIDataPacket {
     /// Length of dump buffer.
     pub dump_len: u32,
     /// Length of HE-SIG-B field (802.11ax).
+    #[cfg(feature = "esp32c6")]
     pub he_sigb_len: u32,
     /// Indicates if this is a single MPDU.
+    #[cfg(feature = "esp32c6")]
     pub cur_single_mpdu: u32,
     /// Current baseband format.
     pub cur_bb_format: u32,
@@ -436,6 +438,7 @@ pub struct CSIDataPacket {
     /// Indicate whether the reception frame is from interface 1.
     pub rxmatch1: u32,
     /// Indicate whether the reception frame is from interface 0.
+    #[cfg(feature = "esp32c6")]
     pub rxmatch0: u32,
     /// Optional NTP-based Timestamp Indicating the Time CSI Captured.
     pub date_time: Option<DateTime>,
@@ -450,7 +453,7 @@ pub struct CSIDataPacket {
     pub csi_data: Vec<i8, 612>,
 }
 
-#[cfg(feature = "esp32c6")]
+#[cfg(any(feature = "esp32c5", feature = "esp32c6"))]
 impl CSIDataPacket {
     /// Prints Recieved CSI Data Packet with it's Metadata.
     ///
@@ -489,9 +492,11 @@ impl CSIDataPacket {
     pub fn dump_len(&self) -> u32 {
         self.dump_len
     }
+    #[cfg(feature = "esp32c6")]
     pub fn he_sigb_len(&self) -> u32 {
         self.he_sigb_len
     }
+    #[cfg(feature = "esp32c6")]
     pub fn cur_single_mpdu(&self) -> u32 {
         self.cur_single_mpdu
     }
@@ -525,6 +530,7 @@ impl CSIDataPacket {
     pub fn rxmatch1(&self) -> u32 {
         self.rxmatch1
     }
+    #[cfg(feature = "esp32c6")]
     pub fn rxmatch0(&self) -> u32 {
         self.rxmatch0
     }

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -632,13 +632,34 @@ impl Default for WifiSnifferConfig {
 }
 
 impl WifiSnifferConfig {
-    /// Override the 2.4 GHz channel (1–14) the sniffer locks to.
+    /// Override the channel the sniffer locks to.
+    ///
+    /// Must be a valid IEEE 802.11 **primary** channel number — pass the
+    /// primary, not the wider-channel center notation that routers
+    /// commonly display:
+    ///
+    /// - **2.4 GHz**: `1`–`14`
+    /// - **5 GHz**: `36, 40, 44, 48, 52, 56, 60, 64, 100, 104, 108, 112,
+    ///   116, 120, 124, 128, 132, 136, 140, 144, 149, 153, 157, 161, 165`
+    ///   (regulatory-domain dependent — some restricted by `country_info`)
+    ///
+    /// Center-channel labels (`38, 46, ...` for HT40; `42, 58, 106, ...`
+    /// for VHT80; `50, 114` for VHT160; `154` for the 153/157 HT40 pair)
+    /// are **not** accepted here — `esp_wifi_set_channel` panics with
+    /// `InvalidArguments`. For example, a router showing "channel 154"
+    /// is using primary `153` (or `157`); pass that primary and the chip
+    /// will sniff the full 40 MHz block automatically per 802.11.
+    ///
+    /// On dual-band chips (currently ESP32-C5), the band is auto-selected
+    /// from the channel number — channels `>= 36` switch the radio to
+    /// `BandMode::_5G`, otherwise `BandMode::_2_4G`. On 2.4-GHz-only
+    /// chips, passing any 5 GHz channel will fail at runtime.
     pub fn with_channel(mut self, channel: u8) -> Self {
         self.channel = channel;
         self
     }
 
-    /// Configured 2.4 GHz channel.
+    /// Configured channel (2.4 GHz: 1–14, 5 GHz: 36–165).
     pub fn channel(&self) -> u8 {
         self.channel
     }

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -7,9 +7,9 @@
 //! In terms of hardware, you need to make sure that the device you choose supports WiFi and CSI collection.
 //! Currently supported devices include:
 //! - ESP32
-//! - ESP32-C2
 //! - ESP32-C3
-//! - ESP32-C6
+//! - ESP32-C5 (dual-band 2.4/5 GHz)
+//! - ESP32-C6 (WiFi 6)
 //! - ESP32-S3
 //!
 //! In terms of project and software toolchain setup, you will need to specify the hardware you will be using. To minimize headache, it is recommended that you generate a project using `esp-generate` as explained next.
@@ -28,6 +28,22 @@
 //!
 //! ## Feature Flags
 #![doc = document_features::document_features!()]
+//! ## Logging Backends
+//!
+//! Two logging backends are supported and they are mutually exclusive:
+//!
+//! - **`println` (default)** — plain text via `esp-println`. Decoded by any serial monitor.
+//! - **`defmt`** — compact binary frames via `esp-println`'s `defmt-espflash` backend, decoded by `espflash --monitor --log-format defmt`. The `build.rs` adds `-Tdefmt.x` automatically when this feature is on, so no manual linker-script edits are needed.
+//!
+//! Per-chip cargo aliases ship in `.cargo/config.toml` for both flavors:
+//!
+//! ```bash
+//! cargo esp32c3 --example sniffer_wifi          # println
+//! cargo esp32c3-defmt --example sniffer_wifi    # defmt
+//! ```
+//!
+//! Replace `esp32c3` with any of: `esp32`, `esp32c3`, `esp32c5`, `esp32c6`, `esp32s3`. `-build` and `-build-defmt` variants compile without flashing.
+//!
 //! ## Using the Crate
 //!
 //! Each ESP device is represented as a node in a collection network. For each node, we need to configure its role in the network, the mode of operation, and the CSI collection behavior. The node role determines how the node participates in the network and interacts with other nodes, while the collection mode determines how the node handles CSI data.
@@ -161,15 +177,20 @@
 //! ```
 //! #### Step 3: Create a Station Configuration
 //! ```rust
-//! let client_config = ClientConfig::default()
-//!     .with_ssid("SSID".to_string())
+//! use esp_radio::wifi::sta::StationConfig;
+//! use esp_radio::wifi::AuthenticationMethod;
+//!
+//! let client_config = StationConfig::default()
+//!     .with_ssid("SSID")
 //!     .with_password("PASS".to_string())
-//!     .with_auth_method(esp_radio::wifi::AuthMethod::Wpa2Personal);
+//!     .with_auth_method(AuthenticationMethod::Wpa2Personal);
 //!
 //! let station_config = WifiStationConfig {
 //!    client_config,  // Pass the config we created above
 //! };
 //! ```
+//!
+//! `StationConfig` was renamed from `ClientConfig`, and `AuthMethod` was renamed to `AuthenticationMethod` in `esp-radio` 0.18. `with_ssid` now takes `impl Into<Ssid>`, so a `&str` literal works directly without `.to_string()`.
 //! #### Step 4: Create a CSI Collection Node Instance with the Desired Configuration
 //! ```rust
 //! let mut node = CSINode::new(
@@ -200,20 +221,28 @@
 
 #[cfg(feature = "async-print")]
 use embassy_time::with_timeout;
+#[cfg(feature = "statistics")]
 use portable_atomic::AtomicI64;
 
 use embassy_futures::join::{join, join3};
 use embassy_futures::select::{select, select3, Either, Either3};
 
 use embassy_time::{Duration, Instant, Timer};
+use enumset::EnumSet;
 use esp_radio::esp_now::WifiPhyRate;
-use esp_radio::wifi::{ClientConfig, CsiConfig, Interfaces, Protocol, WifiController};
+use esp_radio::wifi::csi::CsiConfig;
+use esp_radio::wifi::sta::StationConfig;
+use esp_radio::wifi::{Interfaces, Protocol, Protocols, SecondaryChannel, WifiController};
+#[cfg(feature = "esp32c5")]
+use esp_radio::wifi::BandMode;
 
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::signal::Signal;
 use embassy_sync::waitqueue::AtomicWaker;
 
-use heapless::{LinearMap, Vec};
+#[cfg(feature = "statistics")]
+use heapless::LinearMap;
+use heapless::Vec;
 extern crate alloc;
 use serde::{Deserialize, Serialize};
 
@@ -231,6 +260,7 @@ use crate::config::CsiConfig as CsiConfiguration;
 use crate::csi::{CSIDataPacket, RxCSIFmt};
 use crate::peripheral::esp_now::run_esp_now_peripheral;
 
+#[cfg(feature = "statistics")]
 const MAX_TRACKED_PEERS: usize = 16;
 
 /// Lock-free 32-slot MPMC ring used by the WiFi callback to deliver
@@ -280,6 +310,7 @@ static COLLECTION_MODE_CHANGED: Signal<CriticalSectionRawMutex, ()> = Signal::ne
 /// Toggle explicitly with [`set_csi_delivery_mode`].
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum CsiDeliveryMode {
     /// No user delivery. Inline `log_csi` may still run if its gate is
     /// open (controlled by [`set_csi_logging_enabled`]).
@@ -423,7 +454,9 @@ static PERIPHERAL_MAGIC_NUMBER: u32 = !CENTRAL_MAGIC_NUMBER;
 #[cfg(feature = "statistics")]
 static SEQ_DROP_DETECTION_ENABLED: AtomicBool = AtomicBool::new(false);
 
-use portable_atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use portable_atomic::{AtomicBool, Ordering};
+#[cfg(feature = "statistics")]
+use portable_atomic::{AtomicU32, AtomicU64};
 /// Global statistics counters (enabled with the `statistics` feature).
 #[cfg(feature = "statistics")]
 struct GlobalStats {
@@ -486,16 +519,9 @@ fn set_seq_drop_detection(enabled: bool) {
     }
 }
 
+#[cfg(feature = "statistics")]
 fn seq_drop_detection_enabled() -> bool {
-    #[cfg(feature = "statistics")]
-    {
-        SEQ_DROP_DETECTION_ENABLED.load(Ordering::Relaxed)
-    }
-
-    #[cfg(not(feature = "statistics"))]
-    {
-        false
-    }
+    SEQ_DROP_DETECTION_ENABLED.load(Ordering::Relaxed)
 }
 
 // Drives the per-`run_duration` lifecycle. In async-print mode this is the
@@ -582,14 +608,16 @@ impl EspNowConfig {
 }
 
 /// Configuration for Wi-Fi Promiscuous Sniffer mode.
+///
+/// Construct with `WifiSnifferConfig::default()` then chain `with_channel`
+/// to override defaults.
 #[derive(Debug, Clone)]
 pub struct WifiSnifferConfig {
     /// Optional MAC source filter (reserved — not yet wired into the
     /// promiscuous filter setup).
     #[allow(dead_code)]
     mac_filter: Option<[u8; 6]>,
-    /// 2.4 GHz channel (1–14) the sniffer should lock to.
-    pub channel: u8,
+    channel: u8,
 }
 
 impl Default for WifiSnifferConfig {
@@ -603,11 +631,31 @@ impl Default for WifiSnifferConfig {
     }
 }
 
+impl WifiSnifferConfig {
+    /// Override the 2.4 GHz channel (1–14) the sniffer locks to.
+    pub fn with_channel(mut self, channel: u8) -> Self {
+        self.channel = channel;
+        self
+    }
+
+    /// Configured 2.4 GHz channel.
+    pub fn channel(&self) -> u8 {
+        self.channel
+    }
+}
+
 /// Configuration for Wi-Fi Station mode.
 #[derive(Debug, Clone)]
 pub struct WifiStationConfig {
-    /// Underlying esp-radio client configuration (SSID, auth, etc.).
-    pub client_config: ClientConfig,
+    /// Underlying esp-radio station configuration (SSID, auth, etc.).
+    pub client_config: StationConfig,
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for WifiStationConfig {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
+        defmt::write!(fmt, "WifiStationConfig {{ client_config: <opaque> }}");
+    }
 }
 
 // Enum for Central modes, each wrapping its specific config.
@@ -1008,13 +1056,10 @@ impl<'a> CSINode<'a> {
 
         // Tasks Necessary for Central Station & Sniffer
         let sta_interface = if let Node::Central(CentralOpMode::WifiStation(config)) = &self.kind {
-            Some(sta_init(&mut interfaces.sta, config, controller))
+            Some(sta_init(&mut interfaces.station, config, controller))
         } else {
             None
         };
-
-        // Set Wi-Fi mode to Station for all node types
-        controller.set_mode(esp_radio::wifi::WifiMode::Sta).unwrap();
 
         // Build CSI Configuration
         let config = match self.csi_config {
@@ -1035,12 +1080,11 @@ impl<'a> CSINode<'a> {
         // Apply Protocol if specified
         if let Some(protocol) = self.protocol.take() {
             let old_protocol = reconstruct_protocol(&protocol);
-            controller.set_protocol(protocol.into()).unwrap();
+            let protocols = Protocols::default().with_2_4(EnumSet::only(protocol));
+            controller.set_protocols(protocols).unwrap();
             self.protocol = Some(old_protocol);
         }
 
-        // Start the controller
-        controller.start_async().await.unwrap();
         log_ln!("Wi-Fi Controller Started");
         let is_collector = self.collection_mode == CollectionMode::Collector;
         IS_COLLECTOR.store(is_collector, Ordering::Relaxed);
@@ -1070,8 +1114,12 @@ impl<'a> CSINode<'a> {
         // task hot path, stealing cycles from the central TX-completion
         // ISR for no purpose.
         let csi_config_for_recovery = config.clone();
-        if self.io_tasks.rx_enabled {
-            set_csi(controller, config);
+        let is_sniffer = matches!(
+            &self.kind,
+            Node::Peripheral(PeripheralOpMode::WifiSniffer(_))
+        );
+        if self.io_tasks.rx_enabled && !is_sniffer {
+            set_csi(controller, config.clone());
         }
         // The `run_duration` path doesn't use `interfaces.sniffer` — the
         // WifiSniffer arm binds its own local. Only `run()` keeps an
@@ -1107,10 +1155,23 @@ impl<'a> CSINode<'a> {
                     }
                 }
                 PeripheralOpMode::WifiSniffer(sniffer_config) => {
-                    interfaces
-                        .esp_now
-                        .set_channel(sniffer_config.channel)
+                    #[cfg(feature = "esp32c5")]
+                    {
+                        let band = if sniffer_config.channel() >= 36 {
+                            BandMode::_5G
+                        } else {
+                            BandMode::_2_4G
+                        };
+                        controller.set_band_mode(band).unwrap();
+                    }
+                    let sniffer = &interfaces.sniffer;
+                    sniffer.set_promiscuous_mode(true).unwrap();
+                    controller
+                        .set_channel(sniffer_config.channel(), SecondaryChannel::None)
                         .unwrap();
+                    if self.io_tasks.rx_enabled {
+                        set_csi(controller, config.clone());
+                    }
                     // Drop the ESP-NOW receive callback at the C layer.
                     // Rationale: in Rust esp-radio, `rcv_cb` runs for every
                     // ESP-NOW vendor action frame the 802.11 MAC sees and
@@ -1124,14 +1185,12 @@ impl<'a> CSINode<'a> {
                     // registered → frames are silently dropped at the C layer
                     // with zero allocation. Replicate that here for sniffer
                     // mode (we don't consume ESP-NOW data anyway).
-                    extern "C" {
+                    unsafe extern "C" {
                         fn esp_now_unregister_recv_cb() -> i32;
                     }
                     unsafe {
                         let _ = esp_now_unregister_recv_cb();
                     }
-                    let sniffer = &interfaces.sniffer;
-                    sniffer.set_promiscuous_mode(true).unwrap();
                     if self.io_tasks.rx_enabled {
                         join(
                             run_process_csi_packet(),
@@ -1156,7 +1215,7 @@ impl<'a> CSINode<'a> {
 
                     let main_task = run_esp_now_central(
                         &mut interfaces.esp_now,
-                        interfaces.sta.mac_address(),
+                        interfaces.station.mac_address(),
                         esp_now_config,
                         self.traffic_freq_hz,
                         is_collector,
@@ -1204,7 +1263,6 @@ impl<'a> CSINode<'a> {
         }
 
         STOP_SIGNAL.reset();
-        let _ = controller.stop_async().await;
         reset_globals();
     }
 
@@ -1217,13 +1275,10 @@ impl<'a> CSINode<'a> {
 
         // Tasks Necessary for Central Station & Sniffer
         let sta_interface = if let Node::Central(CentralOpMode::WifiStation(config)) = &self.kind {
-            Some(sta_init(&mut interfaces.sta, config, controller))
+            Some(sta_init(&mut interfaces.station, config, controller))
         } else {
             None
         };
-
-        // Set Wi-Fi mode to Station for all node types
-        controller.set_mode(esp_radio::wifi::WifiMode::Sta).unwrap();
 
         // Build CSI Configuration
         let config = match self.csi_config {
@@ -1244,12 +1299,11 @@ impl<'a> CSINode<'a> {
         // Apply Protocol if specified
         if let Some(protocol) = self.protocol.take() {
             let old_protocol = reconstruct_protocol(&protocol);
-            controller.set_protocol(protocol.into()).unwrap();
+            let protocols = Protocols::default().with_2_4(EnumSet::only(protocol));
+            controller.set_protocols(protocols).unwrap();
             self.protocol = Some(old_protocol);
         }
 
-        // Start the controller
-        controller.start_async().await.unwrap();
         log_ln!("Wi-Fi Controller Started");
         let is_collector = self.collection_mode == CollectionMode::Collector;
         IS_COLLECTOR.store(is_collector, Ordering::Relaxed);
@@ -1279,10 +1333,14 @@ impl<'a> CSINode<'a> {
         // task hot path, stealing cycles from the central TX-completion
         // ISR for no purpose.
         let csi_config_for_recovery = config.clone();
-        if self.io_tasks.rx_enabled {
-            set_csi(controller, config);
+        let is_sniffer = matches!(
+            &self.kind,
+            Node::Peripheral(PeripheralOpMode::WifiSniffer(_))
+        );
+        if self.io_tasks.rx_enabled && !is_sniffer {
+            set_csi(controller, config.clone());
         }
-        let sniffer: &esp_radio::wifi::Sniffer<'_> = &interfaces.sniffer;
+        let sniffer: &esp_radio::wifi::sniffer::Sniffer<'_> = &interfaces.sniffer;
 
         // Initialize Nodes based on type
         match &self.kind {
@@ -1308,19 +1366,29 @@ impl<'a> CSINode<'a> {
                     }
                 }
                 PeripheralOpMode::WifiSniffer(sniffer_config) => {
-                    interfaces
-                        .esp_now
-                        .set_channel(sniffer_config.channel)
+                    #[cfg(feature = "esp32c5")]
+                    {
+                        let band = if sniffer_config.channel() >= 36 {
+                            BandMode::_5G
+                        } else {
+                            BandMode::_2_4G
+                        };
+                        controller.set_band_mode(band).unwrap();
+                    }
+                    sniffer.set_promiscuous_mode(true).unwrap();
+                    controller
+                        .set_channel(sniffer_config.channel(), SecondaryChannel::None)
                         .unwrap();
+                    if self.io_tasks.rx_enabled {
+                        set_csi(controller, config.clone());
+                    }
                     // See the sniffer-Collector arm above for rationale.
-                    extern "C" {
+                    unsafe extern "C" {
                         fn esp_now_unregister_recv_cb() -> i32;
                     }
                     unsafe {
                         let _ = esp_now_unregister_recv_cb();
                     }
-                    let sniffer = &interfaces.sniffer;
-                    sniffer.set_promiscuous_mode(true).unwrap();
                     if self.io_tasks.rx_enabled {
                         run_process_csi_packet().await;
                     } else {
@@ -1340,7 +1408,7 @@ impl<'a> CSINode<'a> {
 
                     let main_task = run_esp_now_central(
                         &mut interfaces.esp_now,
-                        interfaces.sta.mac_address(),
+                        interfaces.station.mac_address(),
                         esp_now_config,
                         self.traffic_freq_hz,
                         is_collector,
@@ -1379,8 +1447,27 @@ impl<'a> CSINode<'a> {
         }
 
         STOP_SIGNAL.reset();
-        let _ = controller.stop_async().await;
         reset_globals();
+    }
+}
+
+#[cfg(feature = "esp32c5")]
+fn build_csi_config(csi_config: &CsiConfiguration) -> CsiConfig {
+    CsiConfig {
+        enable: csi_config.enable,
+        acquire_csi_legacy: csi_config.acquire_csi_legacy,
+        acquire_csi_force_lltf: csi_config.acquire_csi_force_lltf,
+        acquire_csi_ht20: csi_config.acquire_csi_ht20,
+        acquire_csi_ht40: csi_config.acquire_csi_ht40,
+        acquire_csi_vht: csi_config.acquire_csi_vht,
+        acquire_csi_su: csi_config.acquire_csi_su,
+        acquire_csi_mu: csi_config.acquire_csi_mu,
+        acquire_csi_dcm: csi_config.acquire_csi_dcm,
+        acquire_csi_beamformed: csi_config.acquire_csi_beamformed,
+        acquire_csi_he_stbc: csi_config.acquire_csi_he_stbc,
+        val_scale_cfg: csi_config.val_scale_cfg,
+        dump_ack_en: csi_config.dump_ack_en,
+        reserved: csi_config.reserved,
     }
 }
 
@@ -1402,7 +1489,7 @@ fn build_csi_config(csi_config: &CsiConfiguration) -> CsiConfig {
     }
 }
 
-#[cfg(not(feature = "esp32c6"))]
+#[cfg(not(any(feature = "esp32c5", feature = "esp32c6")))]
 fn build_csi_config(csi_config: &CsiConfiguration) -> CsiConfig {
     CsiConfig {
         lltf_en: csi_config.lltf_en,
@@ -1486,14 +1573,14 @@ pub fn get_two_way_latency() -> i64 {
 pub(crate) fn set_csi(controller: &mut WifiController, config: CsiConfig) {
     // Set CSI Configuration with callback
     controller
-        .set_csi(config, |info: esp_radio::wifi::wifi_csi_info_t| {
+        .set_csi(config, |info: esp_radio::wifi::csi::WifiCsiInfo<'_>| {
             capture_csi_info(info);
         })
         .unwrap();
 }
 
 // Function to capture CSI info from callback and publish to channel
-fn capture_csi_info(info: esp_radio::wifi::wifi_csi_info_t) {
+fn capture_csi_info(info: esp_radio::wifi::csi::WifiCsiInfo<'_>) {
     // Count every CSI report regardless of mode so `rx_count` / `rx_rate_hz`
     // / `pps_rx` reflect actual radio CSI throughput. This is the only path
     // that fires for sniffer / STA / ESP-NOW collection — counting here keeps
@@ -1516,17 +1603,11 @@ fn capture_csi_info(info: esp_radio::wifi::wifi_csi_info_t) {
     // to run unconditionally — there's no cheaper way to know if the
     // packet is interesting until it's parsed.
 
-    let rssi = if info.rx_ctrl.rssi() > 127 {
-        info.rx_ctrl.rssi() - 256
-    } else {
-        info.rx_ctrl.rssi()
-    };
+    let rssi = info.rssi();
 
     let mut csi_data = Vec::<i8, 612>::new();
-    // let csi_buf = info.buf;
-    let csi_buf_len = info.len;
-    let csi_slice =
-        unsafe { core::slice::from_raw_parts(info.buf as *const i8, csi_buf_len as usize) };
+    let csi_slice = info.buf();
+    let csi_buf_len = csi_slice.len() as u16;
     match csi_data.extend_from_slice(csi_slice) {
         Ok(_) => {}
         Err(_) => {
@@ -1536,77 +1617,69 @@ fn capture_csi_info(info: esp_radio::wifi::wifi_csi_info_t) {
         }
     }
 
-    #[cfg(not(feature = "esp32c6"))]
+    let mac_arr = *info.mac();
+    let timestamp_us = info.timestamp().duration_since_epoch().as_micros() as u32;
+
+    #[cfg(not(any(feature = "esp32c5", feature = "esp32c6")))]
     let csi_packet = CSIDataPacket {
-        sequence_number: info.rx_seq,
+        sequence_number: info.rx_sequence(),
         data_format: RxCSIFmt::Undefined,
         date_time: None,
-        mac: [
-            info.mac[0],
-            info.mac[1],
-            info.mac[2],
-            info.mac[3],
-            info.mac[4],
-            info.mac[5],
-        ],
-        rssi,
-        bandwidth: info.rx_ctrl.cwb(),
-        antenna: info.rx_ctrl.ant(),
-        rate: info.rx_ctrl.rate(),
-        sig_mode: info.rx_ctrl.sig_mode(),
-        mcs: info.rx_ctrl.mcs(),
-        smoothing: info.rx_ctrl.smoothing(),
-        not_sounding: info.rx_ctrl.not_sounding(),
-        aggregation: info.rx_ctrl.aggregation(),
-        stbc: info.rx_ctrl.stbc(),
-        fec_coding: info.rx_ctrl.fec_coding(),
-        sgi: info.rx_ctrl.sgi(),
-        noise_floor: info.rx_ctrl.noise_floor(),
-        ampdu_cnt: info.rx_ctrl.ampdu_cnt(),
-        channel: info.rx_ctrl.channel(),
-        secondary_channel: info.rx_ctrl.secondary_channel(),
-        timestamp: info.rx_ctrl.timestamp(),
-        rx_state: info.rx_ctrl.rx_state(),
-        sig_len: info.rx_ctrl.sig_len(),
+        mac: mac_arr,
+        rssi: rssi as i32,
+        bandwidth: info.cwb() as u32,
+        antenna: info.antenna() as u32,
+        rate: info.rate() as u32,
+        sig_mode: info.packet_mode() as u32,
+        mcs: info.modulation_coding_scheme() as u32,
+        smoothing: info.smoothing() as u32,
+        not_sounding: info.not_sounding() as u32,
+        aggregation: info.aggregation() as u32,
+        stbc: info.space_time_block_code() as u32,
+        fec_coding: info.forward_error_correction_coding() as u32,
+        sgi: info.short_guide_interval() as u32,
+        noise_floor: info.noise_floor() as i32,
+        ampdu_cnt: info.ampdu_count() as u32,
+        channel: info.channel() as u32,
+        secondary_channel: info.secondary_channel() as u32,
+        timestamp: timestamp_us,
+        rx_state: info.rx_state() as u32,
+        sig_len: info.signal_length() as u32,
         csi_data_len: csi_buf_len,
-        csi_data: csi_data,
+        csi_data,
     };
 
-    #[cfg(feature = "esp32c6")]
+    #[cfg(any(feature = "esp32c5", feature = "esp32c6"))]
     let csi_packet = CSIDataPacket {
-        mac: [
-            info.mac[0],
-            info.mac[1],
-            info.mac[2],
-            info.mac[3],
-            info.mac[4],
-            info.mac[5],
-        ],
-        rssi,
-        timestamp: info.rx_ctrl.timestamp(),
-        rate: info.rx_ctrl.rate(),
-        noise_floor: info.rx_ctrl.noise_floor(),
-        sig_len: info.rx_ctrl.sig_len(),
-        rx_state: info.rx_ctrl.rx_state(),
-        dump_len: info.rx_ctrl.dump_len(),
-        he_sigb_len: info.rx_ctrl.he_sigb_len(),
-        cur_single_mpdu: info.rx_ctrl.cur_single_mpdu(),
-        cur_bb_format: info.rx_ctrl.cur_bb_format(),
-        rx_channel_estimate_info_vld: info.rx_ctrl.rx_channel_estimate_info_vld(),
-        rx_channel_estimate_len: info.rx_ctrl.rx_channel_estimate_len(),
-        second: info.rx_ctrl.second(),
-        channel: info.rx_ctrl.channel(),
-        is_group: info.rx_ctrl.is_group(),
-        rxend_state: info.rx_ctrl.rxend_state(),
-        rxmatch3: info.rx_ctrl.rxmatch3(),
-        rxmatch2: info.rx_ctrl.rxmatch2(),
-        rxmatch1: info.rx_ctrl.rxmatch1(),
-        rxmatch0: info.rx_ctrl.rxmatch0(),
+        mac: mac_arr,
+        rssi: rssi as i32,
+        timestamp: timestamp_us,
+        rate: info.rate() as u32,
+        noise_floor: info.noise_floor() as i32,
+        sig_len: info.signal_length() as u32,
+        rx_state: info.rx_state() as u32,
+        dump_len: info.dump_length(),
+        #[cfg(feature = "esp32c6")]
+        he_sigb_len: info.he_sigb_length() as u32,
+        #[cfg(feature = "esp32c6")]
+        cur_single_mpdu: info.cur_single_mpdu() as u32,
+        cur_bb_format: info.cur_bb_format() as u32,
+        rx_channel_estimate_info_vld: info.rx_channel_estimate_info_valid() as u32,
+        rx_channel_estimate_len: info.rx_channel_estimate_length(),
+        second: info.secondary_channel() as u32,
+        channel: info.channel() as u32,
+        is_group: info.is_group() as u32,
+        rxend_state: info.rx_end_state() as u32,
+        rxmatch3: info.rx_match3() as u32,
+        rxmatch2: info.rx_match2() as u32,
+        rxmatch1: info.rx_match1() as u32,
+        #[cfg(feature = "esp32c6")]
+        rxmatch0: info.rx_match0() as u32,
         date_time: None,
-        sequence_number: info.rx_seq,
+        sequence_number: info.rx_sequence(),
         data_format: RxCSIFmt::Undefined,
-        csi_data_len: info.len as u16,
-        csi_data: csi_data,
+        csi_data_len: csi_buf_len,
+        csi_data,
     };
 
     #[cfg(feature = "statistics")]
@@ -1790,12 +1863,13 @@ fn reconstruct_wifi_rate(rate: &WifiPhyRate) -> WifiPhyRate {
 
 fn reconstruct_protocol(protocol: &Protocol) -> Protocol {
     match protocol {
-        Protocol::P802D11B => Protocol::P802D11B,
-        Protocol::P802D11BG => Protocol::P802D11BG,
-        Protocol::P802D11BGN => Protocol::P802D11BGN,
-        Protocol::P802D11BGNLR => Protocol::P802D11BGNLR,
-        Protocol::P802D11LR => Protocol::P802D11LR,
-        Protocol::P802D11BGNAX => Protocol::P802D11BGNAX,
-        _ => Protocol::P802D11BGNLR,
+        Protocol::B => Protocol::B,
+        Protocol::G => Protocol::G,
+        Protocol::N => Protocol::N,
+        Protocol::LR => Protocol::LR,
+        Protocol::A => Protocol::A,
+        Protocol::AC => Protocol::AC,
+        Protocol::AX => Protocol::AX,
+        _ => Protocol::N,
     }
 }

--- a/src/lib/logging/logging.rs
+++ b/src/lib/logging/logging.rs
@@ -11,8 +11,9 @@
 //!
 //! Transport selection (`println!`, JTAG-serial, UART, no-op, or
 //! `defmt`) is driven by the crate's feature flags. When `defmt` is
-//! enabled without `async-print`, `defmt-rtt` is pulled in as the global
-//! logger.
+//! enabled, `esp-println`'s `defmt-espflash` backend is the global
+//! logger — defmt frames stream over the same UART/USB-Serial-JTAG
+//! channel as `println!` and are decoded by `espflash --log-format defmt`.
 
 #[cfg(feature = "async-print")]
 use embedded_io_async::Write;
@@ -22,7 +23,7 @@ use portable_atomic::{AtomicBool, AtomicU8, Ordering};
 use postcard::experimental::max_size::MaxSize;
 
 #[cfg(all(feature = "defmt", not(feature = "async-print")))]
-use defmt_rtt as _;
+use esp_println as _;
 
 #[allow(dead_code)]
 const CSI_LOG_CHANNEL_CAPACITY: usize = 32;
@@ -264,7 +265,7 @@ impl From<u8> for LogMode {
 mod logging_impl {
     use embedded_io_async::{ErrorType, Write};
     use esp_hal::peripherals::Peripherals;
-    #[cfg(all(any(feature = "jtag-serial", feature = "auto"), not(any(feature = "esp32", feature = "esp32c2"))))]
+    #[cfg(all(any(feature = "jtag-serial", feature = "auto"), not(feature = "esp32")))]
     use esp_hal::usb_serial_jtag::UsbSerialJtag;
     use esp_hal::{
         uart::{Config, Uart},
@@ -277,7 +278,7 @@ mod logging_impl {
     pub enum Backend {
         #[cfg(any(feature = "uart", feature = "auto"))]
         Uart(Uart<'static, Async>),
-        #[cfg(all(any(feature = "jtag-serial", feature = "auto"), not(any(feature = "esp32", feature = "esp32c2"))))]
+        #[cfg(all(any(feature = "jtag-serial", feature = "auto"), not(feature = "esp32")))]
         Jtag(UsbSerialJtag<'static, Async>),
     }
 
@@ -296,7 +297,7 @@ mod logging_impl {
                     .map(|_| buf.len())
                     .map_err(|_| embedded_io_async::ErrorKind::Other),
 
-                #[cfg(all(any(feature = "jtag-serial", feature = "auto"), not(any(feature = "esp32", feature = "esp32c2"))))]
+                #[cfg(all(any(feature = "jtag-serial", feature = "auto"), not(feature = "esp32")))]
                 Self::Jtag(driver) => driver
                     .write_all(buf)
                     .await
@@ -316,7 +317,7 @@ mod logging_impl {
                     .await
                     .map_err(|_| embedded_io_async::ErrorKind::Other),
 
-                #[cfg(all(any(feature = "jtag-serial", feature = "auto"), not(any(feature = "esp32", feature = "esp32c2"))))]
+                #[cfg(all(any(feature = "jtag-serial", feature = "auto"), not(feature = "esp32")))]
                 Self::Jtag(driver) => driver
                     .flush()
                     .await
@@ -344,7 +345,7 @@ mod logging_impl {
             }
         }
 
-        #[cfg(all(any(feature = "jtag-serial", feature = "auto"), not(any(feature = "esp32", feature = "esp32c2"))))]
+        #[cfg(all(any(feature = "jtag-serial", feature = "auto"), not(feature = "esp32")))]
         pub fn new_jtag(periphs: Peripherals) -> Self {
             let raw_driver = UsbSerialJtag::new(periphs.USB_DEVICE).into_async();
             Self {
@@ -531,11 +532,13 @@ pub fn init_logger(spawner: embassy_executor::Spawner, log_mode: LogMode) {
         }
         #[cfg(feature = "auto")]
         {
-            #[cfg(not(any(feature = "esp32", feature = "esp32c2")))]
+            #[cfg(not(feature = "esp32"))]
             {
                 let periphs = unsafe { Peripherals::steal() };
                 #[cfg(feature = "esp32c3")]
                 const USB_DEVICE_INT_RAW: *const u32 = 0x60043008 as *const u32;
+                #[cfg(feature = "esp32c5")]
+                const USB_DEVICE_INT_RAW: *const u32 = 0x600D_F008 as *const u32;
                 #[cfg(feature = "esp32c6")]
                 const USB_DEVICE_INT_RAW: *const u32 = 0x6000f008 as *const u32;
                 #[cfg(feature = "esp32s3")]
@@ -558,7 +561,7 @@ pub fn init_logger(spawner: embassy_executor::Spawner, log_mode: LogMode) {
                 spawner.spawn(logger_backend(driver)).unwrap();
             }
         }
-        #[cfg(all(feature = "jtag-serial", not(any(feature = "esp32", feature = "esp32c2"))))]
+        #[cfg(all(feature = "jtag-serial", not(feature = "esp32")))]
         {
             let periphs = unsafe { Peripherals::steal() };
             let driver = LogOutput::new_jtag(periphs);
@@ -630,11 +633,9 @@ fn write_serialized_packet(packet: CSIDataPacket) {
     const PACKET_BUF_SIZE: usize = PACKET_MAX_SIZE + (PACKET_MAX_SIZE / 254) + 1;
 
     let mut buf = [0u8; PACKET_BUF_SIZE];
-    match postcard::to_slice_cobs(&packet, &mut buf) {
-        Ok(cobs_slice) => {
-            log_raw!(cobs_slice);
-        }
-        Err(_) => {}
+    if let Ok(cobs_slice) = postcard::to_slice_cobs(&packet, &mut buf) {
+        let _ = cobs_slice;
+        log_raw!(cobs_slice);
     }
 }
 
@@ -677,7 +678,7 @@ async fn write_text_array_packet(packet: CSIDataPacket, driver: &mut LogOutput) 
     write_field!(packet.timestamp);
     write_field!(packet.sig_len);
     write_field!(packet.rx_state);
-    #[cfg(not(feature = "esp32c6"))]
+    #[cfg(not(any(feature = "esp32c5", feature = "esp32c6")))]
     {
         write_field!(packet.secondary_channel);
         write_field!(packet.sgi);
@@ -692,10 +693,12 @@ async fn write_text_array_packet(packet: CSIDataPacket, driver: &mut LogOutput) 
         write_field!(packet.stbc);
         write_field!(packet.fec_coding);
     }
-    #[cfg(feature = "esp32c6")]
+    #[cfg(any(feature = "esp32c5", feature = "esp32c6"))]
     {
         write_field!(packet.dump_len);
+        #[cfg(feature = "esp32c6")]
         write_field!(packet.he_sigb_len);
+        #[cfg(feature = "esp32c6")]
         write_field!(packet.cur_single_mpdu);
         write_field!(packet.cur_bb_format);
         write_field!(packet.rx_channel_estimate_info_vld);
@@ -707,6 +710,7 @@ async fn write_text_array_packet(packet: CSIDataPacket, driver: &mut LogOutput) 
         write_field!(packet.rxmatch3);
         write_field!(packet.rxmatch2);
         write_field!(packet.rxmatch1);
+        #[cfg(feature = "esp32c6")]
         write_field!(packet.rxmatch0);
     }
     write_field!(packet.sig_len);
@@ -767,7 +771,7 @@ fn write_text_array_packet(packet: CSIDataPacket) {
     write_field!(packet.timestamp);
     write_field!(packet.sig_len);
     write_field!(packet.rx_state);
-    #[cfg(not(feature = "esp32c6"))]
+    #[cfg(not(any(feature = "esp32c5", feature = "esp32c6")))]
     {
         write_field!(packet.secondary_channel);
         write_field!(packet.sgi);
@@ -782,10 +786,12 @@ fn write_text_array_packet(packet: CSIDataPacket) {
         write_field!(packet.stbc);
         write_field!(packet.fec_coding);
     }
-    #[cfg(feature = "esp32c6")]
+    #[cfg(any(feature = "esp32c5", feature = "esp32c6"))]
     {
         write_field!(packet.dump_len);
+        #[cfg(feature = "esp32c6")]
         write_field!(packet.he_sigb_len);
+        #[cfg(feature = "esp32c6")]
         write_field!(packet.cur_single_mpdu);
         write_field!(packet.cur_bb_format);
         write_field!(packet.rx_channel_estimate_info_vld);
@@ -797,6 +803,7 @@ fn write_text_array_packet(packet: CSIDataPacket) {
         write_field!(packet.rxmatch3);
         write_field!(packet.rxmatch2);
         write_field!(packet.rxmatch1);
+        #[cfg(feature = "esp32c6")]
         write_field!(packet.rxmatch0);
     }
     write_field!(packet.sig_len);
@@ -818,6 +825,7 @@ fn write_text_array_packet(packet: CSIDataPacket) {
 }
 
 /// Header line emitted once at the top of an ESP32-CSI-Tool capture.
+#[allow(dead_code)]
 const ESP_CSI_TOOL_HEADER: &str = "type,role,mac,rssi,rate,sig_mode,mcs,bandwidth,smoothing,not_sounding,aggregation,stbc,fec_coding,sgi,noise_floor,ampdu_cnt,channel,secondary_channel,local_timestamp,ant,sig_len,rx_state,real_time_set,real_timestamp,len,CSI_DATA\n";
 
 /// Write `val` followed by a single space into `buf[*offset..]`, advancing
@@ -970,7 +978,7 @@ fn format_csi_tool_into(packet: &CSIDataPacket, buf: &mut [u8]) -> usize {
     buf[p] = b',';
     p += 1;
 
-    #[cfg(not(feature = "esp32c6"))]
+    #[cfg(not(any(feature = "esp32c5", feature = "esp32c6")))]
     {
         write_u32(buf, &mut p, packet.sig_mode);
         buf[p] = b',';
@@ -1024,7 +1032,7 @@ fn format_csi_tool_into(packet: &CSIDataPacket, buf: &mut [u8]) -> usize {
         buf[p] = b',';
         p += 1;
     }
-    #[cfg(feature = "esp32c6")]
+    #[cfg(any(feature = "esp32c5", feature = "esp32c6"))]
     {
         write_slice(buf, &mut p, b"0,0,0,0,0,0,0,0,0,");
         write_i32(buf, &mut p, packet.noise_floor);
@@ -1193,13 +1201,13 @@ fn write_csi_tool_packet(packet: CSIDataPacket) {
     }
 
     let t0 = embassy_time::Instant::now();
-    let n = format_csi_tool_into(&packet, scratch);
+    let _n = format_csi_tool_into(&packet, scratch);
     let t1 = embassy_time::Instant::now();
 
     #[cfg(all(feature = "esp32", any(feature = "uart", feature = "auto")))]
-    uart0_write_bytes_fast(&scratch[..n]);
+    uart0_write_bytes_fast(&scratch[.._n]);
     #[cfg(not(all(feature = "esp32", any(feature = "uart", feature = "auto"))))]
-    log_raw!(&scratch[..n]);
+    log_raw!(&scratch[.._n]);
 
     let t2 = embassy_time::Instant::now();
     SYNC_FORMAT_US.fetch_add(t1.duration_since(t0).as_micros() as u64, Ordering::Relaxed);
@@ -1254,7 +1262,7 @@ async fn write_text_packet(packet: CSIDataPacket, driver: &mut LogOutput) -> Res
         send_line!("timestamp: {}\r\n", packet.timestamp);
         send_line!("sig len: {}\r\n", packet.sig_len);
         send_line!("rx state: {}\r\n", packet.rx_state);
-        #[cfg(not(feature = "esp32c6"))]
+        #[cfg(not(any(feature = "esp32c5", feature = "esp32c6")))]
         {
             send_line!("secondary channel: {}\r\n", packet.secondary_channel);
             send_line!("sgi: {}\r\n", packet.sgi);
@@ -1269,10 +1277,12 @@ async fn write_text_packet(packet: CSIDataPacket, driver: &mut LogOutput) -> Res
             send_line!("stbc: {}\r\n", packet.stbc);
             send_line!("fec coding: {}\r\n", packet.fec_coding);
         }
-        #[cfg(feature = "esp32c6")]
+        #[cfg(any(feature = "esp32c5", feature = "esp32c6"))]
         {
             send_line!("dump len: {}\r\n", packet.dump_len);
+            #[cfg(feature = "esp32c6")]
             send_line!("he sigb len: {}\r\n", packet.he_sigb_len);
+            #[cfg(feature = "esp32c6")]
             send_line!("cur single mpdu: {}\r\n", packet.cur_single_mpdu);
             send_line!("cur bb format: {}\r\n", packet.cur_bb_format);
             send_line!(
@@ -1290,6 +1300,7 @@ async fn write_text_packet(packet: CSIDataPacket, driver: &mut LogOutput) -> Res
             send_line!("rxmatch3: {}\r\n", packet.rxmatch3);
             send_line!("rxmatch2: {}\r\n", packet.rxmatch2);
             send_line!("rxmatch1: {}\r\n", packet.rxmatch1);
+            #[cfg(feature = "esp32c6")]
             send_line!("rxmatch0: {}\r\n", packet.rxmatch0);
         }
 
@@ -1378,7 +1389,7 @@ fn write_text_packet(packet: CSIDataPacket) {
     log_ln!("timestamp: {}", packet.timestamp);
     log_ln!("sig len: {}", packet.sig_len);
     log_ln!("rx state: {}", packet.rx_state);
-    #[cfg(not(feature = "esp32c6"))]
+    #[cfg(not(any(feature = "esp32c5", feature = "esp32c6")))]
     {
         log_ln!("secondary channel: {}", packet.secondary_channel);
         log_ln!("sgi: {}", packet.sgi);
@@ -1393,10 +1404,12 @@ fn write_text_packet(packet: CSIDataPacket) {
         log_ln!("stbc: {}", packet.stbc);
         log_ln!("fec coding: {}", packet.fec_coding);
     }
-    #[cfg(feature = "esp32c6")]
+    #[cfg(any(feature = "esp32c5", feature = "esp32c6"))]
     {
         log_ln!("dump len: {}", packet.dump_len);
+        #[cfg(feature = "esp32c6")]
         log_ln!("he sigb len: {}", packet.he_sigb_len);
+        #[cfg(feature = "esp32c6")]
         log_ln!("cur single mpdu: {}", packet.cur_single_mpdu);
         log_ln!("cur bb format: {}", packet.cur_bb_format);
         log_ln!(
@@ -1414,13 +1427,17 @@ fn write_text_packet(packet: CSIDataPacket) {
         log_ln!("rxmatch3: {}", packet.rxmatch3);
         log_ln!("rxmatch2: {}", packet.rxmatch2);
         log_ln!("rxmatch1: {}", packet.rxmatch1);
+        #[cfg(feature = "esp32c6")]
         log_ln!("rxmatch0: {}", packet.rxmatch0);
     }
 
     log_ln!("sig_len: {}", packet.sig_len);
     log_ln!("data length: {}", packet.csi_data_len);
 
+    #[cfg(not(feature = "defmt"))]
     log_ln!("csi raw data: [{:X?}]", packet.csi_data);
+    #[cfg(feature = "defmt")]
+    log_ln!("csi raw data: [{=[?]}]", packet.csi_data.as_slice());
 }
 
 #[cfg(all(

--- a/src/lib/logging/logging.rs
+++ b/src/lib/logging/logging.rs
@@ -548,30 +548,30 @@ pub fn init_logger(spawner: embassy_executor::Spawner, log_mode: LogMode) {
                 let res = unsafe { (USB_DEVICE_INT_RAW.read_volatile() & SOF_INT_MASK) != 0 };
                 if res == true {
                     let driver = LogOutput::new_jtag(periphs);
-                    spawner.spawn(logger_backend(driver)).unwrap();
+                    spawner.spawn(logger_backend(driver).unwrap());
                 } else {
                     let driver = LogOutput::new_uart(periphs);
-                    spawner.spawn(logger_backend(driver)).unwrap();
+                    spawner.spawn(logger_backend(driver).unwrap());
                 }
             }
             #[cfg(feature = "esp32")]
             {
                 let periphs = unsafe { Peripherals::steal() };
                 let driver = LogOutput::new_uart(periphs);
-                spawner.spawn(logger_backend(driver)).unwrap();
+                spawner.spawn(logger_backend(driver).unwrap());
             }
         }
         #[cfg(all(feature = "jtag-serial", not(feature = "esp32")))]
         {
             let periphs = unsafe { Peripherals::steal() };
             let driver = LogOutput::new_jtag(periphs);
-            spawner.spawn(logger_backend(driver)).unwrap();
+            spawner.spawn(logger_backend(driver).unwrap());
         }
         #[cfg(feature = "uart")]
         {
             let periphs = unsafe { Peripherals::steal() };
             let driver = LogOutput::new_uart(periphs);
-            spawner.spawn(logger_backend(driver)).unwrap();
+            spawner.spawn(logger_backend(driver).unwrap());
         }
 
         #[cfg(not(any(feature = "uart", feature = "jtag-serial", feature = "auto")))]

--- a/src/lib/peripheral/esp_now.rs
+++ b/src/lib/peripheral/esp_now.rs
@@ -27,7 +27,9 @@ use esp_radio::esp_now::{Error as EspNowInnerError, EspNow, EspNowError, PeerInf
 
 use crate::esp_now_pool::PoolFrame;
 
-use portable_atomic::{AtomicBool, AtomicU16, AtomicU32, AtomicU64, AtomicU8};
+use portable_atomic::{AtomicBool, AtomicU16, AtomicU64, AtomicU8};
+#[cfg(feature = "statistics")]
+use portable_atomic::AtomicU32;
 
 use crate::{EspNowConfig, IOTaskConfig};
 
@@ -152,7 +154,9 @@ struct Shared {
     is_collector: AtomicBool,
     central_mac: AtomicU64,
     peer_healthcheck_counter: AtomicU16,
+    #[cfg(feature = "statistics")]
     last_control_sequence: AtomicU32,
+    #[cfg(feature = "statistics")]
     sequence_initialized: AtomicBool,
     pending_recv_time: AtomicU64,
     pending_csu: AtomicU64,
@@ -217,7 +221,7 @@ fn ingest_control_packet(
         if !is_connected {
             // Lock onto the first valid central and add it as a unicast peer.
             let add_res = esp_now.add_peer(PeerInfo {
-                interface: esp_radio::esp_now::EspNowWifiInterface::Sta,
+                interface: esp_radio::esp_now::EspNowWifiInterface::Station,
                 peer_address: r.info.src_address,
                 lmk: None,
                 channel: Some(channel),
@@ -246,7 +250,7 @@ fn ingest_control_packet(
             {
                 if esp_now
                     .add_peer(PeerInfo {
-                        interface: esp_radio::esp_now::EspNowWifiInterface::Sta,
+                        interface: esp_radio::esp_now::EspNowWifiInterface::Station,
                         peer_address: expected,
                         lmk: None,
                         channel: Some(channel),
@@ -352,7 +356,9 @@ async fn responder(
         is_collector: AtomicBool::new(IS_COLLECTOR.load(Ordering::Relaxed)),
         central_mac: AtomicU64::new(0),
         peer_healthcheck_counter: AtomicU16::new(0),
+        #[cfg(feature = "statistics")]
         last_control_sequence: AtomicU32::new(0),
+        #[cfg(feature = "statistics")]
         sequence_initialized: AtomicBool::new(false),
         pending_recv_time: AtomicU64::new(0),
         pending_csu: AtomicU64::new(0),


### PR DESCRIPTION
## Description
This PR updates the crate to the latest Espressif Rust ecosystem, adds support for the ESP32-C5, migrates to Rust Edition 2024, and streamlines the logging configuration.

## Major Changes & Features
- Ecosystem Bump: Upgraded core dependencies (esp-hal ~1.1, esp-radio 0.18.0, esp-rtos 0.3.0, etc.).
- Added ESP32-C5: Full support introduced, including dual-band 2.4/5 GHz handling.
- Removed ESP32-C2: Dropped because the chip lacks CSI hardware support.
- Rust 2024: Codebase fully migrated to the 2024 edition.
- Logging Overhaul: Replaced manual .cargo/config.toml edits with streamlined cargo aliases. defmt frames now decode directly via espflash over USB-Serial-JTAG (no probe-rs required).

## Breaking API Changes
- Struct Renames: ClientConfig is now StationConfig, and AuthMethod is AuthenticationMethod.
- Lifecycle Management: Removed set_mode, start_async, and stop_async. The radio mode is now inferred and managed internally via set_config and Drop.
- Protocol Selection: Switched from individual Protocol::P802D11* variants to an EnumSet<Protocol> approach.
- Event Handling: Replaced wait_for_events with a subscribe() and wait_for_disconnect_async model.
- Sniffer Initialization: The channel field is now private (use with_channel builder). The init sequence is now strictly ordered (band mode -> promiscuous -> channel -> csi) to prevent dropped reports.

## Maintenance & Documentation
- CI matrix updated in GitHub Actions (swapped C2 for C5).
- Added a dedicated cargo-build-defmt CI job to ensure logging backends don't break.
- Documentation, README.md, and Examples completely refreshed to reflect new API usage and logging commands.

## Verification Status
Builds: Successfully compiles with zero warnings across ESP32, C3, C5, C6, and S3 (both println and defmt backends).

Closes #7 #6 